### PR TITLE
fixed bug with unpacking parameters and tests

### DIFF
--- a/fl4health/parameter_exchange/packing_exchanger.py
+++ b/fl4health/parameter_exchange/packing_exchanger.py
@@ -19,7 +19,7 @@ class ParameterExchangerWithControlVariates(ParameterExchangerWithPacking):
         # Ensure that the packed parameters is even as a sanity check. Model paramers and control variates have same
         # size.
         assert len(packed_parameters) % 2 == 0
-        split_size = len(packed_parameters) % 2
+        split_size = len(packed_parameters) // 2
         return packed_parameters[:split_size], packed_parameters[split_size:]
 
 

--- a/tests/parameter_exchange/test_packing_exchanger.py
+++ b/tests/parameter_exchange/test_packing_exchanger.py
@@ -32,6 +32,9 @@ def test_parameter_exchanger_with_control_variates(get_ndarrays: NDArrays) -> No
 
     unpacked_model_weights, unpacked_control_variates = exchanger.unpack_parameters(packed_params)
 
+    assert len(unpacked_model_weights) == len(model_weights)
+    assert len(unpacked_control_variates) == len(control_variates)
+
     for model_weight, unpacked_model_weight in zip(model_weights, unpacked_model_weights):
         assert model_weight.size == unpacked_model_weight.size
 


### PR DESCRIPTION
# PR Type
Bug fix

# Short Description
Fixed a bug in the `unpack_parameters()` method in `ParameterExchangerWithControlVariates` that causes the unpacked parameters to always be empty.

# Tests Added
Two additional assert statements in `test_packing_exchanger.py` to check that the result of unpacking has the same size as the original parameters.