### PR TITLE
FedPer Implementation

### DIFF
--- a/examples/fedper_example/README.md
+++ b/examples/fedper_example/README.md
@@ -1,5 +1,5 @@
-# FENDA Federated Learning Example
-This example provides an example of training a FENDA type model on a non-IID subset of the MNIST data. The FL server
+# FedPer Federated Learning Example
+This example provides an example of training a FedPer type model on a non-IID subset of the MNIST data. The FL server
 expects three clients to be spun up (i.e. it will wait until three clients report in before starting training). Each client
 has a modified version of the MNIST dataset. This modification essentially subsamples a certain number from the original
 training and validation sets of MNIST in order to synthetically induce local variations in the statistical properties
@@ -21,7 +21,7 @@ to install all of the dependencies for this project.
 
 The next step is to start the server by running
 ```
-python -m examples.fenda_example.server  --config_path /path/to/config.yaml
+python -m examples.fedper_example.server  --config_path /path/to/config.yaml
 ```
 from the FL4Health directory. The following arguments must be present in the specified config file:
 * `n_clients`: number of clients the server waits for in order to run the FL training
@@ -35,7 +35,7 @@ from the FL4Health directory. The following arguments must be present in the spe
 Once the server has started and logged "FL starting," the next step, in separate terminals, is to start the three
 clients. This is done by simply running (remembering to activate your environment)
 ```
-python -m examples.fenda_example.client --dataset_path /path/to/data --minority_numbers <sequence of numbers>
+python -m examples.fedper_example.client --dataset_path /path/to/data --minority_numbers <sequence of numbers>
 ```
 **NOTE**: The argument `dataset_path` has two functions, depending on whether the dataset exists locally or not. If
 the dataset already exists at the path specified, it will be loaded from there. Otherwise, the dataset will be

--- a/examples/fedper_example/README.md
+++ b/examples/fedper_example/README.md
@@ -1,0 +1,48 @@
+# FENDA Federated Learning Example
+This example provides an example of training a FENDA type model on a non-IID subset of the MNIST data. The FL server
+expects three clients to be spun up (i.e. it will wait until three clients report in before starting training). Each client
+has a modified version of the MNIST dataset. This modification essentially subsamples a certain number from the original
+training and validation sets of MNIST in order to synthetically induce local variations in the statistical properties
+of the clients training/validation data. In theory, the models should be able to perform well on their local data
+while learning from other clients data that has different statistical properties. The subsampling is specified by
+sending a list of integers between 0-9 to the clients when they are run with the argument `--minority_numbers`.
+
+The server has some custom metrics aggregation and uses Federated Averaging as its server-side optimization. The implementation uses a special type of weight exchange based on named-layer identification.
+
+## Running the Example
+In order to run the example, first ensure you have the virtual env of your choice activated and run
+```
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+to install all of the dependencies for this project.
+
+## Starting Server
+
+The next step is to start the server by running
+```
+python -m examples.fenda_example.server  --config_path /path/to/config.yaml
+```
+from the FL4Health directory. The following arguments must be present in the specified config file:
+* `n_clients`: number of clients the server waits for in order to run the FL training
+* `local_epochs`: number of epochs each client will train for locally
+* `batch_size`: size of the batches each client will train on
+* `n_server_rounds`: The number of rounds to run FL
+* `downsampling_ratio`: The amount of downsampling to perform for minority digits
+
+## Starting Clients
+
+Once the server has started and logged "FL starting," the next step, in separate terminals, is to start the three
+clients. This is done by simply running (remembering to activate your environment)
+```
+python -m examples.fenda_example.client --dataset_path /path/to/data --minority_numbers <sequence of numbers>
+```
+**NOTE**: The argument `dataset_path` has two functions, depending on whether the dataset exists locally or not. If
+the dataset already exists at the path specified, it will be loaded from there. Otherwise, the dataset will be
+automatically downloaded to the path specified and used in the run.
+
+The argument `minority_numbers` specifies which digits (0-9) in the MNIST dataset the client will subsample to
+simulate non-IID data between clients. For example `--minority_numbers 1 2 3 4 5` will ensure that the client
+downsamples these digits (using the `downsampling_ratio` specified to the config).
+
+After both clients have been started federated learning should commence.

--- a/examples/fedper_example/client.py
+++ b/examples/fedper_example/client.py
@@ -28,6 +28,8 @@ class MnistFedPerClient(MoonClient):
         device: torch.device,
         minority_numbers: Set[int],
     ) -> None:
+        # We inherit from a MOON client here intentionally to be able to use auxiliary losses associated with the
+        # global module's feature space in addition to the personalized architecture of FedPer.
         super().__init__(data_path=data_path, metrics=metrics, device=device)
         self.minority_numbers = minority_numbers
 
@@ -39,6 +41,8 @@ class MnistFedPerClient(MoonClient):
         return train_loader, val_loader
 
     def get_model(self, config: Config) -> nn.Module:
+        # NOTE: Flatten features is set to true to make the model compatible with the MOON contrastive loss function,
+        # which requires the intermediate feature representations to be flattened for similarity calculations.
         model: nn.Module = FedPerModel(
             global_feature_extractor=FedPerGloalFeatureExtractor(),
             local_prediction_head=FedPerLocalPredictionHead(),

--- a/examples/fedper_example/client.py
+++ b/examples/fedper_example/client.py
@@ -1,0 +1,73 @@
+import argparse
+from pathlib import Path
+from typing import Sequence, Set, Tuple
+
+import flwr as fl
+import torch
+import torch.nn as nn
+from flwr.common.typing import Config
+from torch.nn.modules.loss import _Loss
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+
+from examples.models.fedper_cnn import FedPerGloalFeatureExtractor, FedPerLocalPredictionHead
+from fl4health.clients.moon_client import MoonClient
+from fl4health.model_bases.fedper_base import FedPerModel
+from fl4health.parameter_exchange.layer_exchanger import FixedLayerExchanger
+from fl4health.parameter_exchange.parameter_exchanger_base import ParameterExchanger
+from fl4health.utils.load_data import load_mnist_data
+from fl4health.utils.metrics import Accuracy, Metric
+from fl4health.utils.sampler import MinorityLabelBasedSampler
+
+
+class MnistFedPerClient(MoonClient):
+    def __init__(
+        self,
+        data_path: Path,
+        metrics: Sequence[Metric],
+        device: torch.device,
+        minority_numbers: Set[int],
+    ) -> None:
+        super().__init__(data_path=data_path, metrics=metrics, device=device)
+        self.minority_numbers = minority_numbers
+
+    def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:
+        batch_size = self.narrow_config_type(config, "batch_size", int)
+        downsample_percentage = self.narrow_config_type(config, "downsampling_ratio", float)
+        sampler = MinorityLabelBasedSampler(list(range(10)), downsample_percentage, self.minority_numbers)
+        train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler)
+        return train_loader, val_loader
+
+    def get_model(self, config: Config) -> nn.Module:
+        model: nn.Module = FedPerModel(
+            global_feature_extractor=FedPerGloalFeatureExtractor(),
+            local_prediction_head=FedPerLocalPredictionHead(),
+            flatten_features=True,
+        ).to(self.device)
+        return model
+
+    def get_optimizer(self, config: Config) -> Optimizer:
+        return torch.optim.AdamW(self.model.parameters(), lr=0.001)
+
+    def get_criterion(self, config: Config) -> _Loss:
+        return torch.nn.CrossEntropyLoss()
+
+    def get_parameter_exchanger(self, config: Config) -> ParameterExchanger:
+        assert isinstance(self.model, FedPerModel)
+        return FixedLayerExchanger(self.model.layers_to_exchange())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FL Client Main")
+    parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
+    parser.add_argument(
+        "--minority_numbers", default=[], nargs="*", help="MNIST numbers to be in the minority for the current client"
+    )
+    args = parser.parse_args()
+
+    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    data_path = Path(args.dataset_path)
+    minority_numbers = {int(number) for number in args.minority_numbers}
+    client = MnistFedPerClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    fl.client.start_numpy_client(server_address="0.0.0.0:8080", client=client)
+    client.shutdown()

--- a/examples/fedper_example/config.yaml
+++ b/examples/fedper_example/config.yaml
@@ -1,0 +1,10 @@
+# Parameters that describe server
+n_server_rounds: 3 # The number of rounds to run FL
+
+# Parameters that describe clients
+n_clients: 3 # The number of clients in the FL experiment
+local_epochs: 1 # The number of epochs to complete for client
+batch_size: 32 # The batch size for client training
+
+# Downsampling settings per client
+downsampling_ratio: 0.1 # percentage of original mnist data to keep for minority numbers

--- a/examples/fedper_example/server.py
+++ b/examples/fedper_example/server.py
@@ -1,0 +1,87 @@
+import argparse
+from functools import partial
+from typing import Any, Dict
+
+import flwr as fl
+from flwr.common.parameter import ndarrays_to_parameters
+from flwr.common.typing import Config, Parameters
+from flwr.server.strategy import FedAvg
+
+from examples.models.fedper_cnn import FedPerGloalFeatureExtractor, FedPerLocalPredictionHead
+from examples.simple_metric_aggregation import evaluate_metrics_aggregation_fn, fit_metrics_aggregation_fn
+from fl4health.model_bases.fedper_base import FedPerModel
+from fl4health.utils.config import load_config
+
+
+def get_initial_model_parameters() -> Parameters:
+    # Initializing the model parameters on the server side.
+    # Currently uses the Pytorch default initialization for the model parameters.
+    initial_model = FedPerModel(
+        global_feature_extractor=FedPerGloalFeatureExtractor(),
+        local_prediction_head=FedPerLocalPredictionHead(),
+        flatten_features=True,
+    )
+    return ndarrays_to_parameters([val.cpu().numpy() for _, val in initial_model.state_dict().items()])
+
+
+def fit_config(
+    local_epochs: int,
+    batch_size: int,
+    n_server_rounds: int,
+    downsampling_ratio: float,
+    current_round: int,
+) -> Config:
+    return {
+        "local_epochs": local_epochs,
+        "batch_size": batch_size,
+        "n_server_rounds": n_server_rounds,
+        "downsampling_ratio": downsampling_ratio,
+        "current_server_round": current_round,
+    }
+
+
+def main(config: Dict[str, Any]) -> None:
+    # This function will be used to produce a config that is sent to each client to initialize their own environment
+    fit_config_fn = partial(
+        fit_config,
+        config["local_epochs"],
+        config["batch_size"],
+        config["n_server_rounds"],
+        config["downsampling_ratio"],
+    )
+
+    # Server performs simple FedAveraging as its server-side optimization strategy
+    strategy = FedAvg(
+        min_fit_clients=config["n_clients"],
+        min_evaluate_clients=config["n_clients"],
+        # Server waits for min_available_clients before starting FL rounds
+        min_available_clients=config["n_clients"],
+        on_fit_config_fn=fit_config_fn,
+        # We use the same fit config function, as nothing changes for eval
+        on_evaluate_config_fn=fit_config_fn,
+        fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
+        evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
+        initial_parameters=get_initial_model_parameters(),
+    )
+
+    fl.server.start_server(
+        server_address="0.0.0.0:8080",
+        config=fl.server.ServerConfig(num_rounds=config["n_server_rounds"]),
+        strategy=strategy,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FL Server Main")
+    parser.add_argument(
+        "--config_path",
+        action="store",
+        type=str,
+        help="Path to configuration file.",
+        default="examples/fedper_example/config.yaml",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config_path)
+
+    main(config)

--- a/examples/fenda_example/client.py
+++ b/examples/fenda_example/client.py
@@ -26,7 +26,7 @@ class MnistFendaClient(FendaClient):
         device: torch.device,
         minority_numbers: Set[int],
     ) -> None:
-        super().__init__(data_path=data_path, metrics=metrics, device=device)
+        super().__init__(data_path=data_path, metrics=metrics, device=device, perfcl_loss_weights=(1.0, 1.0))
         self.minority_numbers = minority_numbers
 
     def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:

--- a/examples/models/fedper_cnn.py
+++ b/examples/models/fedper_cnn.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class FedPerLocalPredictionHead(nn.Module):
+    def __init__(self) -> None:
+        self.fc1 = nn.Linear(120, 84)
+        self.fc2 = nn.Linear(84, 10)
+
+    def head_forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        x = F.relu(self.fc1(input_tensor))
+        x = self.fc2(x)
+        return x
+
+
+class FedPerGloalFeatureExtractor(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 4 * 4, 120)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 4 * 4)
+        x = F.relu(self.fc1(x))
+        return x

--- a/examples/models/fedper_cnn.py
+++ b/examples/models/fedper_cnn.py
@@ -5,10 +5,11 @@ import torch.nn.functional as F
 
 class FedPerLocalPredictionHead(nn.Module):
     def __init__(self) -> None:
+        super().__init__()
         self.fc1 = nn.Linear(120, 84)
         self.fc2 = nn.Linear(84, 10)
 
-    def head_forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
         x = F.relu(self.fc1(input_tensor))
         x = self.fc2(x)
         return x

--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -68,7 +68,7 @@ class ApflClient(BasicClient):
         losses.backward.backward()
         self.local_optimizer.step()
 
-        # Return dictionairy of predictions where key is used to name respective MetricMeters
+        # Return dictionary of predictions where key is used to name respective MetricMeters
         return losses, preds
 
     def get_parameter_exchanger(self, config: Config) -> FixedLayerExchanger:
@@ -108,6 +108,6 @@ class ApflClient(BasicClient):
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
         """
-        Returns a dictionairy with global and local optimizers with string keys 'global' and 'local' respectively.
+        Returns a dictionary with global and local optimizers with string keys 'global' and 'local' respectively.
         """
         raise NotImplementedError

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -366,7 +366,7 @@ class BasicClient(NumpyFlClient):
     def set_optimizer(self, config: Config) -> None:
         """
         Method called in the the setup_client method to set optimizer attribute returned by used-defined get_optimizer.
-        In the simplest case, get_optimizer returns an optimizer. For more advanced use cases where a dictionairy of
+        In the simplest case, get_optimizer returns an optimizer. For more advanced use cases where a dictionary of
         string and optimizer are returned (ie APFL), the use must override this method.
         """
         optimizer = self.get_optimizer(config)
@@ -419,7 +419,7 @@ class BasicClient(NumpyFlClient):
     def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
         """
         Called after training with the number of local_steps performed over the FL round and
-        the corresponding loss dictionairy.
+        the corresponding loss dictionary.
         """
         pass
 

--- a/fl4health/clients/evaluate_client.py
+++ b/fl4health/clients/evaluate_client.py
@@ -198,7 +198,7 @@ class EvaluateClient(NumpyFlClient):
 
     def compute_loss(self, preds: torch.Tensor, target: torch.Tensor) -> Losses:
         """
-        Computes loss given preds and torch and the user defined criterion. Optionally includes dictionairy of
+        Computes loss given preds and torch and the user defined criterion. Optionally includes dictionary of
         loss components if you wish to train the total loss as well as sub losses if they exist.
         """
         loss = self.criterion(preds, target)

--- a/fl4health/clients/fed_prox_client.py
+++ b/fl4health/clients/fed_prox_client.py
@@ -123,7 +123,7 @@ class FedProxClient(BasicClient):
     def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
         """
         Called after training with the number of local_steps performed over the FL round and
-        the corresponding loss dictionairy.
+        the corresponding loss dictionary.
         """
         # Store current loss which is the vanilla loss without the proximal term added in
         self.current_loss = loss_dict["checkpoint"]

--- a/fl4health/clients/fenda_client.py
+++ b/fl4health/clients/fenda_client.py
@@ -95,7 +95,6 @@ class FendaClient(BasicClient):
         return preds, features
 
     def get_parameters(self, config: Config) -> NDArrays:
-
         # Save the parameters of the old model
         assert isinstance(self.model, FendaModel)
         if self.contrastive_loss_weight or self.perfcl_loss_weights:
@@ -105,7 +104,6 @@ class FendaClient(BasicClient):
         return super().get_parameters(config)
 
     def set_parameters(self, parameters: NDArrays, config: Config) -> None:
-
         # Set the parameters of the model
         super().set_parameters(parameters, config)
 

--- a/fl4health/clients/fenda_client.py
+++ b/fl4health/clients/fenda_client.py
@@ -205,7 +205,7 @@ class FendaClient(BasicClient):
         """
 
         loss = self.criterion(preds["prediction"], target)
-        total_loss = loss
+        total_loss = loss.clone()
         additional_losses = {}
 
         # Optimal cos_sim_loss_weight for FedIsic dataset is 100.0

--- a/fl4health/clients/moon_client.py
+++ b/fl4health/clients/moon_client.py
@@ -59,11 +59,12 @@ class MoonClient(BasicClient):
             the old model are returned. All predictions included in dictionary will be used to compute metrics.
         """
         preds, features = self.model(input)
-        old_features = torch.zeros(self.len_old_models_buffer, *features.size()).to(self.device)
+        old_features = torch.zeros(self.len_old_models_buffer, *features["features"].size()).to(self.device)
         for i, old_model in enumerate(self.old_models_list):
-            old_features[i] = old_model(input)[1]
-        global_features = self.global_model(input)[1]
-        features.update({"global_features": global_features, "old_features": old_features})
+            _, old_model_features = old_model(input)
+            old_features[i] = old_model_features["features"]
+        _, global_model_features = self.global_model(input)
+        features.update({"global_features": global_model_features["features"], "old_features": old_features})
         return preds, features
 
     def get_contrastive_loss(

--- a/fl4health/clients/moon_client.py
+++ b/fl4health/clients/moon_client.py
@@ -6,6 +6,7 @@ from flwr.common.typing import Config, NDArrays
 
 from fl4health.checkpointing.checkpointer import TorchCheckpointer
 from fl4health.clients.basic_client import BasicClient
+from fl4health.model_bases.moon_base import MoonModel
 from fl4health.utils.losses import Losses, LossMeterType
 from fl4health.utils.metrics import Metric
 
@@ -89,6 +90,7 @@ class MoonClient(BasicClient):
         return self.ce_criterion(logits, labels)
 
     def set_parameters(self, parameters: NDArrays, config: Config) -> None:
+        assert isinstance(self.model, MoonModel)
         # Save the parameters of the old local model
         old_model = self.clone_and_freeze_model(self.model)
         self.old_models_list.append(old_model)

--- a/fl4health/clients/moon_client.py
+++ b/fl4health/clients/moon_client.py
@@ -6,7 +6,6 @@ from flwr.common.typing import Config, NDArrays
 
 from fl4health.checkpointing.checkpointer import TorchCheckpointer
 from fl4health.clients.basic_client import BasicClient
-from fl4health.model_bases.moon_base import MoonModel
 from fl4health.utils.losses import Losses, LossMeterType
 from fl4health.utils.metrics import Metric
 
@@ -89,8 +88,6 @@ class MoonClient(BasicClient):
         return self.ce_criterion(logits, labels)
 
     def set_parameters(self, parameters: NDArrays, config: Config) -> None:
-        assert isinstance(self.model, MoonModel)
-
         # Save the parameters of the old local model
         old_model = self.clone_and_freeze_model(self.model)
         self.old_models_list.append(old_model)

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -201,7 +201,7 @@ class ScaffoldClient(BasicClient):
     def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
         """
         Called after training with the number of local_steps performed over the FL round and
-        the corresponding loss dictionairy.
+        the corresponding loss dictionary.
         """
         self.update_control_variates(local_steps)
 

--- a/fl4health/model_bases/apfl_base.py
+++ b/fl4health/model_bases/apfl_base.py
@@ -4,8 +4,10 @@ from typing import Dict, List
 import torch
 import torch.nn as nn
 
+from fl4health.model_bases.partial_layer_exchange_model import PartialLayerExchangeModel
 
-class ApflModule(nn.Module):
+
+class ApflModule(PartialLayerExchangeModel):
     def __init__(
         self,
         model: nn.Module,
@@ -28,7 +30,7 @@ class ApflModule(nn.Module):
         return self.local_model(input)
 
     def forward(self, input: torch.Tensor) -> Dict[str, torch.Tensor]:
-        # Forward return dictionairy because APFL has multiple different prediction types
+        # Forward return dictionary because APFL has multiple different prediction types
         global_logits = self.global_forward(input)
         local_logits = self.local_forward(input)
         personal_logits = self.alpha * local_logits + (1.0 - self.alpha) * global_logits
@@ -69,5 +71,7 @@ class ApflModule(nn.Module):
         self.alpha = alpha
 
     def layers_to_exchange(self) -> List[str]:
-        layers_to_exchange: List[str] = [layer for layer in self.state_dict().keys() if "global_model" in layer]
+        layers_to_exchange: List[str] = [
+            layer for layer in self.state_dict().keys() if layer.startswith("global_model.")
+        ]
         return layers_to_exchange

--- a/fl4health/model_bases/fedper_base.py
+++ b/fl4health/model_bases/fedper_base.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+
+from fl4health.model_bases.partial_layer_exchange_model import PartialLayerExchangeModel
+
+
+class FedPerModel(PartialLayerExchangeModel):
+    def __init__(
+        self, global_feature_extractor: nn.Module, local_prediction_head: nn.Module, flatten_features: bool = False
+    ) -> None:
+        """
+        Implementation of the FedPer model structure: https://arxiv.org/pdf/1912.00818.pdf
+        The architecture is fairly straightforward. The global module represents the first set of layers. These are
+        learned with FedAvg. The local_prediction_head are the last layers, these are not exchanged with the server.
+        The approach resembles FENDA, but vertical rather than parallel models.
+
+        NOTE: The structure is similar to MOON but only a subset of the components are aggregated server-side.
+
+        Args:
+            global_feature_extractor (nn.Module): First set of layers. These are exchanged with the server.
+            local_prediction_head (nn.Module): Final set of layers. These are not aggregated by the server.
+            flatten_features (bool): Whether or not the forward should flatten the produced features across the batch.
+                Defaults to False.
+        """
+        super().__init__()
+        self.global_feature_extractor = global_feature_extractor
+        self.local_prediction_head = local_prediction_head
+        self.flatten_features = flatten_features
+
+    def layers_to_exchange(self) -> List[str]:
+        return [
+            layer_name for layer_name in self.state_dict().keys() if layer_name.startswith("global_feature_extractor.")
+        ]
+
+    def forward(self, input: torch.Tensor) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+        # input is expected to be of shape (batch_size, *)
+        features = self.global_feature_extractor.forward(input)
+        preds = {"prediction": self.local_prediction_head.forward(features)}
+        features = {"features": features} if not self.flatten_features else {features.reshape(len(features), -1)}
+        # Return preds and features as separate dictionary
+        return preds, features

--- a/fl4health/model_bases/fedper_base.py
+++ b/fl4health/model_bases/fedper_base.py
@@ -22,6 +22,8 @@ class FedPerModel(PartialLayerExchangeModel):
             global_feature_extractor (nn.Module): First set of layers. These are exchanged with the server.
             local_prediction_head (nn.Module): Final set of layers. These are not aggregated by the server.
             flatten_features (bool): Whether or not the forward should flatten the produced features across the batch.
+                Flattening of the features can be used to ensure that the features produced are compatible with the
+                MOON-based constrative loss functions. This allows a FedPer model to be used with a MOON client.
                 Defaults to False.
         """
         super().__init__()

--- a/fl4health/model_bases/fedper_base.py
+++ b/fl4health/model_bases/fedper_base.py
@@ -38,6 +38,8 @@ class FedPerModel(PartialLayerExchangeModel):
         # input is expected to be of shape (batch_size, *)
         features = self.global_feature_extractor.forward(input)
         preds = {"prediction": self.local_prediction_head.forward(features)}
-        features = {"features": features} if not self.flatten_features else {features.reshape(len(features), -1)}
+        features = (
+            {"features": features} if not self.flatten_features else {"features": features.reshape(len(features), -1)}
+        )
         # Return preds and features as separate dictionary
         return preds, features

--- a/fl4health/model_bases/fenda_base.py
+++ b/fl4health/model_bases/fenda_base.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Tuple
 import torch
 import torch.nn as nn
 
+from fl4health.model_bases.partial_layer_exchange_model import PartialLayerExchangeModel
+
 
 class FendaJoinMode(Enum):
     CONCATENATE = "CONCATENATE"
@@ -33,7 +35,7 @@ class FendaHeadModule(nn.Module, ABC):
         return self.head_forward(head_input)
 
 
-class FendaModel(nn.Module):
+class FendaModel(PartialLayerExchangeModel):
     def __init__(self, local_module: nn.Module, global_module: nn.Module, model_head: FendaHeadModule) -> None:
         super().__init__()
         self.local_module = local_module
@@ -52,5 +54,5 @@ class FendaModel(nn.Module):
             "local_features": local_output.reshape(len(local_output), -1),
             "global_features": global_output.reshape(len(global_output), -1),
         }
-        # Return preds and features as separate dictionairy as in moon base
+        # Return preds and features as separate dictionary as in moon base
         return preds, features

--- a/fl4health/model_bases/moon_base.py
+++ b/fl4health/model_bases/moon_base.py
@@ -18,5 +18,5 @@ class MoonModel(nn.Module):
         x = self.base_module.forward(input)
         features = self.projection_module.forward(x) if self.projection_module else x
         preds = self.head_module.forward(features)
-        # Return preds and features as seperate dictionairy as in fenda base
-        return {"prediction": preds}, {"features": features.view(len(features), -1)}
+        # Return preds and features as seperate dictionary as in fenda base
+        return {"prediction": preds}, {"features": features.reshape(len(features), -1)}

--- a/fl4health/model_bases/moon_base.py
+++ b/fl4health/model_bases/moon_base.py
@@ -12,11 +12,17 @@ class MoonModel(nn.Module):
         self.base_module = base_module
         self.projection_module = projection_module
         self.head_module = head_module
+        # Features are forced to be flattened in this model, as it is expected to always be used with the contrastive
+        # loss function. However, inheriting models, such as FedPer may override this variable.
+        self.flatten_features = True
 
     def forward(self, input: torch.Tensor) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
         # input is expected to be of shape (batch_size, *)
         x = self.base_module.forward(input)
         features = self.projection_module.forward(x) if self.projection_module else x
-        preds = self.head_module.forward(features)
+        preds = {"prediction": self.head_module.forward(features)}
+        features = (
+            {"features": features} if not self.flatten_features else {"features": features.reshape(len(features), -1)}
+        )
         # Return preds and features as seperate dictionary as in fenda base
-        return {"prediction": preds}, {"features": features.reshape(len(features), -1)}
+        return preds, features

--- a/fl4health/model_bases/partial_layer_exchange_model.py
+++ b/fl4health/model_bases/partial_layer_exchange_model.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+import torch.nn as nn
+
+
+class PartialLayerExchangeModel(nn.Module, ABC):
+    @abstractmethod
+    def layers_to_exchange(self) -> List[str]:
+        raise NotImplementedError

--- a/fl4health/server/tabular_feature_alignment_server.py
+++ b/fl4health/server/tabular_feature_alignment_server.py
@@ -93,7 +93,6 @@ class TabularFeatureAlignmentServer(FlServer):
         # the feature information needed to perform feature alignment. Then the server
         # gathers information from the clients that is necessary for initializing the global model.
         if not self.initial_polls_complete:
-
             # If the server does not have the needed feature info a priori,
             # then it requests such information from the clients before the
             # very first fitting round.

--- a/research/flamby/fed_ixi/fenda/client.py
+++ b/research/flamby/fed_ixi/fenda/client.py
@@ -36,7 +36,6 @@ class FedIxiFendaClient(FendaClient):
         contrastive_activate: bool = False,
         perfcl_activate: bool = False,
     ) -> None:
-
         super().__init__(
             data_path=data_path,
             metrics=metrics,

--- a/research/flamby/fed_ixi/moon/moon_model.py
+++ b/research/flamby/fed_ixi/moon/moon_model.py
@@ -10,7 +10,6 @@ from research.flamby.utils import shutoff_batch_norm_tracking
 
 class HeadClassifier(nn.Module):
     def __init__(self, out_channels_first_layer: int, monte_carlo_dropout: float = 0.0) -> None:
-
         # We're doing 3D segmentation, so hardcode
         dimensions = 3
         # Binary segmentation so out_classes = 2

--- a/tests/clients/test_fenda_client.py
+++ b/tests/clients/test_fenda_client.py
@@ -61,3 +61,36 @@ def test_computing_contrastive_loss(get_fenda_client: FendaClient) -> None:  # n
     contrastive_loss = fenda_client.compute_contrastive_loss(features, positive_pairs, negative_pairs)
 
     assert contrastive_loss == pytest.approx(0.6931, rel=0.01)
+
+
+@pytest.mark.parametrize("local_module,global_module,head_module", [(FeatureCnn(), FeatureCnn(), FendaHeadCnn())])
+def test_computing_loss(get_fenda_client: FendaClient) -> None:  # noqa
+    torch.manual_seed(42)
+    fenda_client = get_fenda_client
+    fenda_client.temperature = 0.5
+    fenda_client.perfcl_loss_weights = (1.0, 1.0)
+    fenda_client.criterion = torch.nn.CrossEntropyLoss()
+
+    local_features = torch.tensor([[1, 1, 1], [1, 1, 1]]).float()
+    global_features = torch.tensor([[1, 1, 1], [1, 1, 1]]).float()
+    old_local_features = torch.tensor([[0, 0, 0], [0, 0, 0]]).float()
+    old_global_features = torch.tensor([[0, 0, 0], [0, 0, 0]]).float()
+    aggregated_global_features = torch.tensor([[1, 1, 1], [1, 1, 1]]).float()
+    preds = {"prediction": torch.tensor([[1.0, 0.0], [0.0, 1.0]])}
+    target = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+    features = {
+        "local_features": local_features,
+        "old_local_features": old_local_features,
+        "global_features": global_features,
+        "old_global_features": old_global_features,
+        "aggregated_global_features": aggregated_global_features,
+    }
+    loss = fenda_client.compute_loss(preds=preds, target=target, features=features)
+
+    assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
+    assert loss.checkpoint.item() != loss.backward.item()
+
+    auxiliary_loss_total = (loss.backward - loss.checkpoint).item()
+    contrastive_minimize = loss.additional_losses["contrastive_loss_minimize"].item()
+    contrastive_maximize = loss.additional_losses["contrastive_loss_maximize"].item()
+    assert pytest.approx(auxiliary_loss_total, abs=0.001) == (contrastive_minimize + contrastive_maximize)

--- a/tests/clients/test_moon_client.py
+++ b/tests/clients/test_moon_client.py
@@ -26,3 +26,50 @@ def test_setting_parameters(get_client: MoonClient) -> None:  # noqa
     for i in range(len(params)):
         assert (params[i] == old_model_params[i]).all()
         assert (new_params[i] == global_model_params[i]).all()
+
+
+@pytest.mark.parametrize("type,model", [(MoonClient, MoonModel(FeatureCnn(), HeadCnn()))])
+def test_contrastive_loss(get_client: MoonClient) -> None:  # noqa
+    torch.manual_seed(42)
+    moon_client = get_client
+
+    global_features = torch.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+    local_features = torch.tensor([[[1.0, 2.0], [2.0, 1.0]], [[2.0, 1.0], [1.0, -1.0]]])
+    previous_local_features = torch.tensor([[[1.0, 2.0], [2.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+
+    # Default temperature is 0.5
+    contrastive_loss = moon_client.get_contrastive_loss(
+        features=local_features.reshape(len(local_features), -1),
+        global_features=global_features.reshape(len(global_features), -1),
+        old_features=previous_local_features.reshape(1, len(previous_local_features), -1),
+    )
+
+    assert pytest.approx(0.837868, abs=0.0001) == contrastive_loss
+
+
+@pytest.mark.parametrize("type,model", [(MoonClient, MoonModel(FeatureCnn(), HeadCnn()))])
+def test_compute_loss(get_client: MoonClient) -> None:  # noqa
+    torch.manual_seed(42)
+    moon_client = get_client
+    # Dummy to ensure the compute loss function in the moon client is executed
+    moon_client.old_models_list = [moon_client.model]
+    moon_client.contrastive_weight = 1.0
+    moon_client.criterion = torch.nn.CrossEntropyLoss()
+
+    global_features = torch.tensor([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+    local_features = torch.tensor([[[1.0, 2.0], [2.0, 1.0]], [[2.0, 1.0], [1.0, -1.0]]])
+    previous_local_features = torch.tensor([[[1.0, 2.0], [2.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+
+    preds = {"prediction": torch.tensor([[1.0, 0.0], [0.0, 1.0]])}
+    target = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+    features = {
+        "features": local_features.reshape(len(local_features), -1),
+        "global_features": global_features.reshape(len(global_features), -1),
+        "old_features": previous_local_features.reshape(1, len(previous_local_features), -1),
+    }
+
+    loss = moon_client.compute_loss(preds=preds, features=features, target=target)
+
+    assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
+    assert pytest.approx(0.837868, abs=0.0001) == loss.additional_losses["contrastive_loss"]
+    assert pytest.approx(0.837868 + 0.8132616, abs=0.0001) == loss.backward.item()

--- a/tests/models/test_apfl_base.py
+++ b/tests/models/test_apfl_base.py
@@ -1,0 +1,12 @@
+from fl4health.model_bases.apfl_base import ApflModule
+from tests.test_utils.models_for_test import ToyConvNet
+
+
+def test_apfl_model_gets_correct_layers() -> None:
+    model = ApflModule(ToyConvNet())
+    layers_to_exchange = model.layers_to_exchange()
+    filtered_layer_names = [
+        layer_name for layer_name in model.state_dict().keys() if layer_name.startswith("global_model.")
+    ]
+    for test_layer, expected_layer in zip(layers_to_exchange, filtered_layer_names):
+        assert test_layer == expected_layer

--- a/tests/models/test_fedper_base.py
+++ b/tests/models/test_fedper_base.py
@@ -6,7 +6,7 @@ def test_fedper_model_gets_correct_layers() -> None:
     model = FedPerModel(FeatureCnn(), HeadCnn())
     layers_to_exchange = model.layers_to_exchange()
     filtered_layer_names = [
-        layer_name for layer_name in model.state_dict().keys() if layer_name.startswith("global_feature_extractor.")
+        layer_name for layer_name in model.state_dict().keys() if layer_name.startswith("base_module.")
     ]
     for test_layer, expected_layer in zip(layers_to_exchange, filtered_layer_names):
         assert test_layer == expected_layer

--- a/tests/models/test_fedper_base.py
+++ b/tests/models/test_fedper_base.py
@@ -2,7 +2,7 @@ from fl4health.model_bases.fedper_base import FedPerModel
 from tests.test_utils.models_for_test import FeatureCnn, HeadCnn
 
 
-def test_apfl_model_gets_correct_layers() -> None:
+def test_fedper_model_gets_correct_layers() -> None:
     model = FedPerModel(FeatureCnn(), HeadCnn())
     layers_to_exchange = model.layers_to_exchange()
     filtered_layer_names = [

--- a/tests/models/test_fedper_base.py
+++ b/tests/models/test_fedper_base.py
@@ -1,0 +1,12 @@
+from fl4health.model_bases.fedper_base import FedPerModel
+from tests.test_utils.models_for_test import FeatureCnn, HeadCnn
+
+
+def test_apfl_model_gets_correct_layers() -> None:
+    model = FedPerModel(FeatureCnn(), HeadCnn())
+    layers_to_exchange = model.layers_to_exchange()
+    filtered_layer_names = [
+        layer_name for layer_name in model.state_dict().keys() if layer_name.startswith("global_feature_extractor.")
+    ]
+    for test_layer, expected_layer in zip(layers_to_exchange, filtered_layer_names):
+        assert test_layer == expected_layer

--- a/tests/models/test_fenda_base.py
+++ b/tests/models/test_fenda_base.py
@@ -2,7 +2,7 @@ from fl4health.model_bases.fenda_base import FendaModel
 from tests.test_utils.models_for_test import FeatureCnn, FendaHeadCnn
 
 
-def test_apfl_model_gets_correct_layers() -> None:
+def test_fenda_model_gets_correct_layers() -> None:
     model = FendaModel(FeatureCnn(), FeatureCnn(), FendaHeadCnn())
     layers_to_exchange = model.layers_to_exchange()
     filtered_layer_names = [

--- a/tests/models/test_fenda_base.py
+++ b/tests/models/test_fenda_base.py
@@ -1,0 +1,12 @@
+from fl4health.model_bases.fenda_base import FendaModel
+from tests.test_utils.models_for_test import FeatureCnn, FendaHeadCnn
+
+
+def test_apfl_model_gets_correct_layers() -> None:
+    model = FendaModel(FeatureCnn(), FeatureCnn(), FendaHeadCnn())
+    layers_to_exchange = model.layers_to_exchange()
+    filtered_layer_names = [
+        layer_name for layer_name in model.state_dict().keys() if layer_name.startswith("global_module.")
+    ]
+    for test_layer, expected_layer in zip(layers_to_exchange, filtered_layer_names):
+        assert test_layer == expected_layer


### PR DESCRIPTION
# PR Type
**Feature**

# Short Description

Clickup Ticket: https://app.clickup.com/t/8686ckn31

This PR adds in the FedPer method into the repository. The addition is fairly straightforward within our infrastructure. It's essentially just a globally trained feature extractor with a locally trained classification head in each client. I added an example using the infrastructure while also training it with MOON. So the example client **inherits** from the MOON client to apply the auxiliary losses to the model along with local personalization, which I thought was nice.

In the course of adding the method, I noticed a few small bugs in MOON and the auxiliary losses (like PerFCL) in the FENDA approaches. These have been fixed and tests have been added to ensure that they are indeed fixed.

# Tests Added

Added losses associated with MOON's contrastive loss calculations and the loss computations of MOON, FENDA, FedProx, and FedPer
