### PR TITLE
Federated ensemble

### DIFF
--- a/examples/ensemble_example/README.md
+++ b/examples/ensemble_example/README.md
@@ -1,0 +1,39 @@
+# Federated Learning with an Ensemble of Models Example
+This is an example of training an ensemble of models in a federated manner. Ensembles of models are often leveraged in prediction tasks involving biomedical images to account for the large variation in the input distribution.
+
+In this demo, an ensemble of 3 models is trained on a federated variant of the MNIST data that is heterogenous. The FL server expects three clients to be spun up (i.e. it will wait until three clients report in before starting training). Each client has a modified version of the MNIST dataset. This modification essentially subsamples a certain number from the original training and validation sets of MNIST in order to synthetically induce local variations in the statistical properties of the clients training/validation data. In theory, the models should be able to perform well on their local data while learning from other clients data that has different statistical properties. The proportion of labels at each client is determined by dirichlet distribtuion across the classes. The lower the beta parameter is for each class, the higher the degree of the label heterogeneity.
+
+The server has some custom metrics aggregation and uses Federated Averaging as its server-side optimization. The implementation uses a special type of weight exchange based on named-layer identification.
+
+## Running the Example
+In order to run the example, first ensure you have the virtual env of your choice activated and run
+```
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+to install all of the dependencies for this project.
+
+## Starting Server
+
+The next step is to start the server by running
+```
+python -m examples.ensemble_example.server  --config_path /path/to/config.yaml
+```
+from the FL4Health directory. The following arguments must be present in the specified config file:
+* `n_clients`: number of clients the server waits for in order to run the FL training
+* `local_epochs`: number of epochs each client will train for locally
+* `batch_size`: size of the batches each client will train on
+* `n_server_rounds`: The number of rounds to run FL
+
+## Starting Clients
+
+Once the server has started and logged "FL starting," the next step, in separate terminals, is to start the three
+clients. This is done by simply running (remembering to activate your environment)
+```
+python -m examples.ensemble_example.client --dataset_path /path/to/data
+```
+**NOTE**: The argument `dataset_path` has two functions, depending on whether the dataset exists locally or not. If
+the dataset already exists at the path specified, it will be loaded from there. Otherwise, the dataset will be
+automatically downloaded to the path specified and used in the run.
+
+After all three clients have been started, federated learning should commence.

--- a/examples/ensemble_example/README.md
+++ b/examples/ensemble_example/README.md
@@ -3,7 +3,7 @@ This is an example of training an ensemble of models in a federated manner. Ense
 
 In this demo, an ensemble of 3 models is trained on a federated variant of the MNIST data that is heterogenous. The FL server expects three clients to be spun up (i.e. it will wait until three clients report in before starting training). Each client has a modified version of the MNIST dataset. This modification essentially subsamples a certain number from the original training and validation sets of MNIST in order to synthetically induce local variations in the statistical properties of the clients training/validation data. In theory, the models should be able to perform well on their local data while learning from other clients data that has different statistical properties. The proportion of labels at each client is determined by dirichlet distribtuion across the classes. The lower the beta parameter is for each class, the higher the degree of the label heterogeneity.
 
-The server has some custom metrics aggregation and uses Federated Averaging as its server-side optimization. The implementation uses a special type of weight exchange based on named-layer identification.
+The server has some custom metrics aggregation and uses Federated Averaging as its server-side optimization.
 
 ## Running the Example
 In order to run the example, first ensure you have the virtual env of your choice activated and run

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -22,22 +22,22 @@ class MnistEnsembleClient(EnsembleClient):
     def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:
         batch_size = self.narrow_config_type(config, "batch_size", int)
         sampler = DirichletLabelBasedSampler(list(range(10)), sample_percentage=0.75)
-        train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler)
+        train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler=sampler)
         return train_loader, val_loader
 
     def get_model(self, config: Config) -> nn.Module:
         ensemble_models: Dict[str, nn.Module] = {
-            "ensemble-model-0": ConfigurableMnistNet(out_channel_mult=1).to(self.device),
-            "ensemble-model-1": ConfigurableMnistNet(out_channel_mult=2).to(self.device),
-            "ensemble-model-2": ConfigurableMnistNet(out_channel_mult=3).to(self.device),
+            "model_0": ConfigurableMnistNet(out_channel_mult=1).to(self.device),
+            "model_1": ConfigurableMnistNet(out_channel_mult=2).to(self.device),
+            "model_2": ConfigurableMnistNet(out_channel_mult=3).to(self.device),
         }
         return EnsembleModel(ensemble_models)
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
         ensemble_optimizers: Dict[str, torch.optim.Optimizer] = {
-            "ensemble-model-0": torch.optim.AdamW(self.model.models["ensemble-model-0"].parameters(), lr=0.01),
-            "ensemble-model-1": torch.optim.AdamW(self.model.models["ensemble-model-1"].parameters(), lr=0.01),
-            "ensemble-model-2": torch.optim.AdamW(self.model.models["ensemble-model-2"].parameters(), lr=0.01),
+            "model_0": torch.optim.AdamW(self.model.model_0.parameters(), lr=0.01),  # type: ignore
+            "model_1": torch.optim.AdamW(self.model.model_1.parameters(), lr=0.01),  # type: ignore
+            "model_2": torch.optim.AdamW(self.model.model_2.parameters(), lr=0.01),  # type: ignore
         }
         return ensemble_optimizers
 

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -21,7 +21,7 @@ from fl4health.utils.sampler import DirichletLabelBasedSampler
 class MnistEnsembleClient(EnsembleClient):
     def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:
         batch_size = self.narrow_config_type(config, "batch_size", int)
-        sampler = DirichletLabelBasedSampler(list(range(10)), sample_percentage=0.75)
+        sampler = DirichletLabelBasedSampler(list(range(10)), sample_percentage=float(config["sample_percentage"]))
         train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler=sampler)
         return train_loader, val_loader
 

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -1,0 +1,58 @@
+import argparse
+from pathlib import Path
+from typing import Dict, Tuple
+
+import flwr as fl
+import torch
+import torch.nn as nn
+from flwr.common.typing import Config
+from torch.nn.modules.loss import _Loss
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+
+from examples.models.ensemble_cnn import ConfigurableMnistNet
+from fl4health.clients.ensemble_client import EnsembleClient
+from fl4health.model_bases.ensemble_base import EnsembleModel
+from fl4health.utils.load_data import load_mnist_data
+from fl4health.utils.metrics import Accuracy
+from fl4health.utils.sampler import DirichletLabelBasedSampler
+
+
+class MnistEnsembleClient(EnsembleClient):
+    def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:
+        batch_size = self.narrow_config_type(config, "batch_size", int)
+        sampler = DirichletLabelBasedSampler(list(range(10)), sample_percentage=0.75)
+        train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler)
+        return train_loader, val_loader
+
+    def get_model(self, config: Config) -> nn.Module:
+        ensemble_models: Dict[str, nn.Module] = {
+            "ensemble-model-0": ConfigurableMnistNet(out_channel_mult=1).to(self.device),
+            "ensemble-model-1": ConfigurableMnistNet(out_channel_mult=2).to(self.device),
+            "ensemble-model-2": ConfigurableMnistNet(out_channel_mult=3).to(self.device),
+        }
+        return EnsembleModel(ensemble_models)
+
+    def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
+        ensemble_optimizers: Dict[str, torch.optim.Optimizer] = {
+            "ensemble-model-0": torch.optim.AdamW(self.model.models["ensemble-model-0"].parameters(), lr=0.01),
+            "ensemble-model-1": torch.optim.AdamW(self.model.models["ensemble-model-1"].parameters(), lr=0.01),
+            "ensemble-model-2": torch.optim.AdamW(self.model.models["ensemble-model-2"].parameters(), lr=0.01),
+        }
+        return ensemble_optimizers
+
+    def get_criterion(self, config: Config) -> _Loss:
+        return torch.nn.CrossEntropyLoss()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FL Client Main")
+    parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
+
+    args = parser.parse_args()
+
+    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    data_path = Path(args.dataset_path)
+
+    client = MnistEnsembleClient(data_path, [Accuracy()], DEVICE)
+    fl.client.start_numpy_client(server_address="0.0.0.0:8080", client=client)

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -25,7 +25,7 @@ class MnistEnsembleClient(EnsembleClient):
         train_loader, val_loader, _ = load_mnist_data(self.data_path, batch_size, sampler=sampler)
         return train_loader, val_loader
 
-    def get_model(self, config: Config) -> nn.Module:
+    def get_model(self, config: Config) -> EnsembleModel:
         ensemble_models: Dict[str, nn.Module] = {
             "model_0": ConfigurableMnistNet(out_channel_mult=1).to(self.device),
             "model_1": ConfigurableMnistNet(out_channel_mult=2).to(self.device),

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -35,9 +35,9 @@ class MnistEnsembleClient(EnsembleClient):
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
         ensemble_optimizers: Dict[str, torch.optim.Optimizer] = {
-            "model_0": torch.optim.AdamW(self.model.model_0.parameters(), lr=0.01),  # type: ignore
-            "model_1": torch.optim.AdamW(self.model.model_1.parameters(), lr=0.01),  # type: ignore
-            "model_2": torch.optim.AdamW(self.model.model_2.parameters(), lr=0.01),  # type: ignore
+            "model_0": torch.optim.AdamW(self.model.ensemble_models["model_0"].parameters(), lr=0.01),
+            "model_1": torch.optim.AdamW(self.model.ensemble_models["model_1"].parameters(), lr=0.01),
+            "model_2": torch.optim.AdamW(self.model.ensemble_models["model_2"].parameters(), lr=0.01),
         }
         return ensemble_optimizers
 

--- a/examples/ensemble_example/config.yaml
+++ b/examples/ensemble_example/config.yaml
@@ -1,0 +1,7 @@
+# Parameters that describe server
+n_server_rounds: 5 # The number of rounds to run FL
+
+# Parameters that describe clients
+n_clients: 3 # The number of clients in the FL experiment
+local_epochs: 1 # The number of epochs to complete for client
+batch_size: 128 # The batch size for client training

--- a/examples/ensemble_example/server.py
+++ b/examples/ensemble_example/server.py
@@ -26,12 +26,15 @@ def get_initial_model_parameters() -> Parameters:
     return ndarrays_to_parameters([val.cpu().numpy() for _, val in initial_model.state_dict().items()])
 
 
-def fit_config(local_epochs: int, batch_size: int, n_server_rounds: int, current_round: int) -> Config:
+def fit_config(
+    sample_percentage: float, local_epochs: int, batch_size: int, n_server_rounds: int, current_round: int
+) -> Config:
     return {
         "current_server_round": current_round,
         "local_epochs": local_epochs,
         "batch_size": batch_size,
         "n_server_rounds": n_server_rounds,
+        "sample_percentage": sample_percentage,
     }
 
 
@@ -39,6 +42,7 @@ def main(config: Dict[str, Any]) -> None:
     # This function will be used to produce a config that is sent to each client to initialize their own environment
     fit_config_fn = partial(
         fit_config,
+        float(config["sample_percentage"]),
         config["local_epochs"],
         config["batch_size"],
         config["n_server_rounds"],

--- a/examples/ensemble_example/server.py
+++ b/examples/ensemble_example/server.py
@@ -1,0 +1,81 @@
+import argparse
+from functools import partial
+from typing import Any, Dict
+
+import flwr as fl
+import torch.nn as nn
+from flwr.common.parameter import ndarrays_to_parameters
+from flwr.common.typing import Config, Parameters
+from flwr.server.strategy import FedAvg
+
+from examples.models.ensemble_cnn import ConfigurableMnistNet
+from examples.simple_metric_aggregation import evaluate_metrics_aggregation_fn, fit_metrics_aggregation_fn
+from fl4health.model_bases.ensemble_base import EnsembleModel
+from fl4health.utils.config import load_config
+
+
+def get_initial_model_parameters() -> Parameters:
+    # Initializing the model parameters on the server side.
+    # Currently uses the Pytorch default initialization for the model parameters.
+    ensemble_models: Dict[str, nn.Module] = {
+        "ensemble-model-0": ConfigurableMnistNet(out_channel_mult=1),
+        "ensemble-model-1": ConfigurableMnistNet(out_channel_mult=2),
+        "ensemble-model-2": ConfigurableMnistNet(out_channel_mult=3),
+    }
+    initial_model = EnsembleModel(ensemble_models)
+    return ndarrays_to_parameters([val.cpu().numpy() for _, val in initial_model.state_dict().items()])
+
+
+def fit_config(local_epochs: int, batch_size: int, n_server_rounds: int, current_round: int) -> Config:
+    return {
+        "current_server_round": current_round,
+        "local_epochs": local_epochs,
+        "batch_size": batch_size,
+        "n_server_rounds": n_server_rounds,
+    }
+
+
+def main(config: Dict[str, Any]) -> None:
+    # This function will be used to produce a config that is sent to each client to initialize their own environment
+    fit_config_fn = partial(
+        fit_config,
+        config["local_epochs"],
+        config["batch_size"],
+        config["n_server_rounds"],
+    )
+
+    # Server performs simple FedAveraging as its server-side optimization strategy
+    strategy = FedAvg(
+        min_fit_clients=config["n_clients"],
+        min_evaluate_clients=config["n_clients"],
+        # Server waits for min_available_clients before starting FL rounds
+        min_available_clients=config["n_clients"],
+        on_fit_config_fn=fit_config_fn,
+        # We use the same fit config function, as nothing changes for eval
+        on_evaluate_config_fn=fit_config_fn,
+        fit_metrics_aggregation_fn=fit_metrics_aggregation_fn,
+        evaluate_metrics_aggregation_fn=evaluate_metrics_aggregation_fn,
+        initial_parameters=get_initial_model_parameters(),
+    )
+
+    fl.server.start_server(
+        server_address="0.0.0.0:8080",
+        config=fl.server.ServerConfig(num_rounds=config["n_server_rounds"]),
+        strategy=strategy,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FL Server Main")
+    parser.add_argument(
+        "--config_path",
+        action="store",
+        type=str,
+        help="Path to configuration file.",
+        default="examples/ensemble_example/config.yaml",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config_path)
+
+    main(config)

--- a/examples/ensemble_example/server.py
+++ b/examples/ensemble_example/server.py
@@ -18,9 +18,9 @@ def get_initial_model_parameters() -> Parameters:
     # Initializing the model parameters on the server side.
     # Currently uses the Pytorch default initialization for the model parameters.
     ensemble_models: Dict[str, nn.Module] = {
-        "ensemble-model-0": ConfigurableMnistNet(out_channel_mult=1),
-        "ensemble-model-1": ConfigurableMnistNet(out_channel_mult=2),
-        "ensemble-model-2": ConfigurableMnistNet(out_channel_mult=3),
+        "model_0": ConfigurableMnistNet(out_channel_mult=1),
+        "model_1": ConfigurableMnistNet(out_channel_mult=2),
+        "model_2": ConfigurableMnistNet(out_channel_mult=3),
     }
     initial_model = EnsembleModel(ensemble_models)
     return ndarrays_to_parameters([val.cpu().numpy() for _, val in initial_model.state_dict().items()])

--- a/examples/models/ensemble_cnn.py
+++ b/examples/models/ensemble_cnn.py
@@ -1,0 +1,22 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ConfigurableMnistNet(nn.Module):
+    def __init__(self, out_channel_mult: int) -> None:
+        super().__init__()
+        self.out_channel_mult = out_channel_mult
+        self.conv1 = nn.Conv2d(1, 8 * out_channel_mult, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(8 * out_channel_mult, 16 * out_channel_mult, 5)
+        self.fc1 = nn.Linear(16 * 4 * 4 * out_channel_mult, 120)
+        self.fc2 = nn.Linear(120, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 4 * 4 * self.out_channel_mult)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return x

--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -102,7 +102,7 @@ class ApflClient(BasicClient):
 
     def set_optimizer(self, config: Config) -> None:
         optimizers = self.get_optimizer(config)
-        assert isinstance(optimizers, dict)
+        assert isinstance(optimizers, dict) and set(("global", "local")) == set(optimizers.keys())
         self.optimizers = optimizers
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:

--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -65,8 +65,7 @@ class ApflClient(BasicClient):
         preds, features = self.predict(input)
         # Parameters of local model are updated to minimize loss of personalized model
         losses = self.compute_loss(preds, features, target)
-        assert isinstance(losses.backward, torch.Tensor)
-        losses.backward.backward()
+        losses.backward["backward"].backward()
         self.optimizers["local"].step()
 
         # Return dictionary of predictions where key is used to name respective MetricMeters

--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -26,8 +26,7 @@ class ApflClient(BasicClient):
 
         self.model: ApflModule
         self.learning_rate: float
-        self.optimizer: torch.optim.Optimizer
-        self.local_optimizer: torch.optim.Optimizer
+        self.optimizers: Dict[str, torch.optim.Optimizer]
 
     def is_start_of_local_training(self, step: int) -> bool:
         return step == 0
@@ -47,18 +46,18 @@ class ApflClient(BasicClient):
         # https://github.com/MLOPTPSU/FedTorch/blob/main/fedtorch/comms/trainings/federated/apfl.py
 
         # Forward pass on global model and update global parameters
-        self.optimizer.zero_grad()
+        self.optimizers["global"].zero_grad()
         global_pred = self.model.global_forward(input)
         global_loss = self.criterion(global_pred, target)
         global_loss.backward()
-        self.optimizer.step()
+        self.optimizers["global"].step()
 
         # Make sure gradients are zero prior to foward passes of global and local model
         # to generate personalized predictions
         # NOTE: We zero the global optimizer grads because they are used (after the backward calculation below)
         # to update the scalar alpha (see update_alpha() where .grad is called.)
-        self.optimizer.zero_grad()
-        self.local_optimizer.zero_grad()
+        self.optimizers["global"].zero_grad()
+        self.optimizers["local"].zero_grad()
 
         # Personal predictions are generated as a convex combination of the output
         # of local and global models
@@ -66,7 +65,7 @@ class ApflClient(BasicClient):
         # Parameters of local model are updated to minimize loss of personalized model
         losses = self.compute_loss(preds, features, target)
         losses.backward.backward()
-        self.local_optimizer.step()
+        self.optimizers["local"].step()
 
         # Return dictionary of predictions where key is used to name respective MetricMeters
         return losses, preds
@@ -101,10 +100,9 @@ class ApflClient(BasicClient):
         return losses
 
     def set_optimizer(self, config: Config) -> None:
-        optimizer_dict = self.get_optimizer(config)
-        assert isinstance(optimizer_dict, dict)
-        self.optimizer = optimizer_dict["global"]
-        self.local_optimizer = optimizer_dict["local"]
+        optimizers = self.get_optimizer(config)
+        assert isinstance(optimizers, dict)
+        self.optimizers = optimizers
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
         """

--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -64,6 +64,7 @@ class ApflClient(BasicClient):
         preds, features = self.predict(input)
         # Parameters of local model are updated to minimize loss of personalized model
         losses = self.compute_loss(preds, features, target)
+        assert isinstance(losses.backward, torch.Tensor)
         losses.backward.backward()
         self.optimizers["local"].step()
 

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -77,7 +77,7 @@ class BasicClient(NumPyClient):
         self.val_loader: DataLoader
         self.num_train_samples: int
         self.num_val_samples: int
-        self.learning_rate: float
+        self.learning_rate: Optional[float] = None
 
     def _maybe_checkpoint(self, current_metric_value: float) -> None:
         """
@@ -106,6 +106,7 @@ class BasicClient(NumPyClient):
         """
         Determines which parameters are sent back to the server for aggregation. This uses a parameter exchanger to
         determine parameters sent.
+
         Args:
             config (Config): The config is sent by the FL server to allow for customization in the function if desired.
 
@@ -122,6 +123,7 @@ class BasicClient(NumPyClient):
         Sets the local model parameters transfered from the server using a parameter exchanger to coordinate how
         parameters are set. If it's the first time the model is being initialized, we assume the full model is being
         initialized and use the FullParameterExchanger() to set all model weights.
+
         Args:
             parameters (NDArrays): Parameters have information about model state to be added to the relevant client
                 model but may contain more information than that.
@@ -339,7 +341,7 @@ class BasicClient(NumPyClient):
         """
         Given a single batch of input and target data, generate predictions, compute loss, update parameters and
         optionally update metrics if they exist. (ie backprop on a single batch of data).
-        Assumes self.model is in train model already.
+        Assumes self.model is in train mode already.
 
         Args:
             input (torch.Tensor): The input to be fed into the model.
@@ -532,10 +534,6 @@ class BasicClient(NumPyClient):
         self.num_val_samples = len(self.val_loader.dataset)  # type: ignore
 
         self.set_optimizer(config)
-        if "global" in self.optimizers:
-            self.learning_rate = self.optimizers["global"].defaults["lr"]
-        else:
-            self.learning_rate = list(self.optimizers.values())[0].defaults["lr"]
 
         self.criterion = self.get_criterion(config).to(self.device)
         self.parameter_exchanger = self.get_parameter_exchanger(config)

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -357,6 +357,7 @@ class BasicClient(NumPyClient):
         losses = self.compute_loss(preds, features, target)
 
         # Compute backward pass and update paramters with optimizer
+        assert isinstance(losses.backward, torch.Tensor)
         losses.backward.backward()
         self.optimizers["global"].step()
 

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -379,8 +379,7 @@ class BasicClient(NumPyClient):
         losses = self.compute_loss(preds, features, target)
 
         # Compute backward pass and update paramters with optimizer
-        assert isinstance(losses.backward, torch.Tensor)
-        losses.backward.backward()
+        losses.backward["backward"].backward()
         self.optimizers["global"].step()
 
         return losses, preds

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -55,10 +55,10 @@ class EnsembleClient(BasicClient):
         """
         super().setup_client(config)
 
-        assert len(self.optimizers) == len(self.model.model_keys)
+        assert len(self.optimizers) == len(self.model.ensemble_models)
         assert all(
             opt_key == model_key
-            for opt_key, model_key in zip(sorted(self.optimizers.keys()), sorted(self.model.model_keys))
+            for opt_key, model_key in zip(sorted(self.optimizers.keys()), sorted(self.model.ensemble_models.keys()))
         )
 
     def set_optimizer(self, config: Config) -> None:
@@ -122,7 +122,7 @@ class EnsembleClient(BasicClient):
         """
         loss_dict = {}
         for key, pred in preds.items():
-            loss_dict[key] = self.criterion(pred, target)
+            loss_dict[key] = self.criterion(pred.float(), target)
 
         individual_model_losses = {key: loss for key, loss in loss_dict.items() if key != "ensemble-pred"}
         backward_loss = individual_model_losses

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -22,7 +22,7 @@ class EnsembleClient(BasicClient):
         checkpointer: Optional[TorchCheckpointer] = None,
     ) -> None:
         """
-        This client enables the training of ensemble of models in a federated manner.
+        This client enables the training of ensemble models in a federated manner.
 
         Args:
             data_path (Path): path to the data to be used to load the data for client-side training
@@ -78,7 +78,7 @@ class EnsembleClient(BasicClient):
         Given a single batch of input and target data, generate predictions
         (both individual models and ensemble prediction), compute loss, update parameters and
         optionally update metrics if they exist. (ie backprop on a single batch of data).
-        Assumes self.model is in train model already. Differs from parent method in that, there is multiple losses
+        Assumes self.model is in train model already. Differs from parent method in that, there are multiple losses
         that we have to do backward passes on and multiple optimizers to update parameters each train step.
 
         Args:

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -21,6 +21,19 @@ class EnsembleClient(BasicClient):
         loss_meter_type: LossMeterType = LossMeterType.AVERAGE,
         checkpointer: Optional[TorchCheckpointer] = None,
     ) -> None:
+        """
+        This client enables the training of ensemble of models in a federated manner.
+
+        Args:
+            data_path (Path): path to the data to be used to load the data for client-side training
+            metrics (Sequence[Metric]): Metrics to be computed based on the labels and predictions of the client model
+            device (torch.device): Device indicator for where to send the model, batches, labels etc. Often 'cpu' or
+                'cuda'
+            loss_meter_type (LossMeterType, optional): Type of meter used to track and compute the losses over
+                each batch. Defaults to LossMeterType.AVERAGE.
+            checkpointer (Optional[TorchCheckpointer], optional): Checkpointer to be used for client-side
+                checkpointing. Defaults to None.
+        """
         super().__init__(
             data_path=data_path,
             metrics=metrics,
@@ -32,6 +45,14 @@ class EnsembleClient(BasicClient):
         self.model: EnsembleModel
 
     def setup_client(self, config: Config) -> None:
+        """
+        Set dataloaders, optimizers, parameter exchangers and other attributes derived from these.
+        Then set initialized attribute to True. Also perform some checks to ensure the keys of the
+        optimizer dictionary are consistent with the model keys.
+
+        Args:
+            config (Config): The config from the server.
+        """
         super().setup_client(config)
 
         assert len(self.optimizers) == len(self.model.model_keys)
@@ -41,12 +62,33 @@ class EnsembleClient(BasicClient):
         )
 
     def set_optimizer(self, config: Config) -> None:
+        """
+        Method called in the the setup_client method to set optimizer attribute returned by used-defined get_optimizer.
+        Ensures that the return value of get_optimizer is a dictionary since that is required for the ensemble client.
+
+        Args:
+            config (Config): The config from the server.
+        """
         optimizers = self.get_optimizer(config)
         assert isinstance(optimizers, dict)
         self.optimizers = optimizers
 
     def train_step(self, input: torch.Tensor, target: torch.Tensor) -> Tuple[Losses, Dict[str, torch.Tensor]]:
+        """
+        Given a single batch of input and target data, generate predictions
+        (both individual models and ensemble prediction), compute loss, update parameters and
+        optionally update metrics if they exist. (ie backprop on a single batch of data).
+        Assumes self.model is in train model already. Differs from parent method in that, there is multiple losses
+        that we have to do backward passes on and multiple optimizers to update parameters each train step.
 
+        Args:
+            input (torch.Tensor): The input to be fed into the model.
+            target (torch.Tensor): The target corresponding to the input.
+
+        Returns:
+            Tuple[Losses, Dict[str, torch.Tensor]]: The losses object from the train step along with
+                a dictionary of any predictions produced by the model.
+        """
         for optimizer in self.optimizers.values():
             optimizer.zero_grad()
 
@@ -65,6 +107,19 @@ class EnsembleClient(BasicClient):
     def compute_loss(
         self, preds: Dict[str, torch.Tensor], features: Dict[str, torch.Tensor], target: torch.Tensor
     ) -> Losses:
+        """
+        Computes loss given predictions (and potentially features) of the model and ground truth data.
+        Since the ensemble client has more than one model, there are multiple backward losses that exist.
+
+        Args:
+            preds (Dict[str, torch.Tensor]): Prediction(s) of the model(s) indexed by name. Anything stored
+                in preds will be used to compute metrics.
+            features: (Dict[str, torch.Tensor]): Feature(s) of the model(s) indexed by name.
+            target: (torch.Tensor): Ground truth data to evaluate predictions against.
+
+        Returns:
+            Losses: Object containing checkpoint loss, backward loss and additional losses indexed by name.
+        """
         loss_dict = {}
         for key, pred in preds.items():
             loss_dict[key] = self.criterion(pred, target)
@@ -77,4 +132,18 @@ class EnsembleClient(BasicClient):
         return losses
 
     def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
+        """
+        Method to be defined by user that returns dictionary of optimizers with keys corresponding to the
+        keys of the models in EnsembleModel that the optimizer applies too.
+
+        Args:
+            config (Config): The config sent from the server.
+
+        Returns:
+            Dict[str, Optimizer]: An optimizer or dictionary of optimizers to
+            train model.
+
+        Raises:
+            NotImplementedError: To be defined in child class.
+        """
         raise NotImplementedError

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -34,10 +34,10 @@ class EnsembleClient(BasicClient):
     def setup_client(self, config: Config) -> None:
         super().setup_client(config)
 
-        assert len(self.optimizers) == len(self.model.models)
+        assert len(self.optimizers) == len(self.model.model_keys)
         assert all(
             opt_key == model_key
-            for opt_key, model_key in zip(sorted(self.optimizers.keys()), sorted(self.model.models.keys()))
+            for opt_key, model_key in zip(sorted(self.optimizers.keys()), sorted(self.model.model_keys))
         )
 
     def set_optimizer(self, config: Config) -> None:
@@ -52,7 +52,9 @@ class EnsembleClient(BasicClient):
 
         preds, features = self.predict(input)
         losses = self.compute_loss(preds, features, target)
-        losses.backward.backward()
+
+        for loss in losses.additional_losses.values():
+            loss.backward()
 
         for optimizer in self.optimizers.values():
             optimizer.step()

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -78,7 +78,7 @@ class EnsembleClient(BasicClient):
         Given a single batch of input and target data, generate predictions
         (both individual models and ensemble prediction), compute loss, update parameters and
         optionally update metrics if they exist. (ie backprop on a single batch of data).
-        Assumes self.model is in train model already. Differs from parent method in that, there are multiple losses
+        Assumes self.model is in train mode already. Differs from parent method in that, there are multiple losses
         that we have to do backward passes on and multiple optimizers to update parameters each train step.
 
         Args:

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Tuple
+
+import torch
+from flwr.common.typing import Config
+from torch.optim import Optimizer
+
+from fl4health.checkpointing.checkpointer import TorchCheckpointer
+from fl4health.clients.basic_client import BasicClient
+from fl4health.model_bases.ensemble_base import EnsembleModel
+from fl4health.utils.losses import Losses, LossMeterType
+from fl4health.utils.metrics import Metric
+
+
+class EnsembleClient(BasicClient):
+    def __init__(
+        self,
+        data_path: Path,
+        metrics: Sequence[Metric],
+        device: torch.device,
+        loss_meter_type: LossMeterType = LossMeterType.AVERAGE,
+        checkpointer: Optional[TorchCheckpointer] = None,
+    ) -> None:
+        super().__init__(
+            data_path=data_path,
+            metrics=metrics,
+            device=device,
+            loss_meter_type=loss_meter_type,
+            checkpointer=checkpointer,
+        )
+
+        self.model: EnsembleModel
+
+    def setup_client(self, config: Config) -> None:
+        super().setup_client(config)
+
+        assert len(self.optimizers) == len(self.model.models)
+        assert all(
+            opt_key == model_key
+            for opt_key, model_key in zip(sorted(self.optimizers.keys()), sorted(self.model.models.keys()))
+        )
+
+    def set_optimizer(self, config: Config) -> None:
+        optimizers = self.get_optimizer(config)
+        assert isinstance(optimizers, dict)
+        self.optimizers = optimizers
+
+    def train_step(self, input: torch.Tensor, target: torch.Tensor) -> Tuple[Losses, Dict[str, torch.Tensor]]:
+
+        for optimizer in self.optimizers.values():
+            optimizer.zero_grad()
+
+        preds, features = self.predict(input)
+        losses = self.compute_loss(preds, features, target)
+        losses.backward.backward()
+
+        for optimizer in self.optimizers.values():
+            optimizer.step()
+
+        return losses, preds
+
+    def compute_loss(
+        self, preds: Dict[str, torch.Tensor], features: Dict[str, torch.Tensor], target: torch.Tensor
+    ) -> Losses:
+        loss_dict = {}
+        for key, pred in preds.items():
+            loss_dict[key] = self.criterion(pred, target)
+
+        individual_model_loss_list = {key: loss for key, loss in loss_dict.items() if key != "ensemble-pred"}
+        backward_loss = torch.sum(torch.tensor(list(individual_model_loss_list.values()), requires_grad=True))
+        checkpoint_loss = loss_dict["ensemble-pred"]
+        additional_losses = individual_model_loss_list
+
+        losses = Losses(checkpoint=checkpoint_loss, backward=backward_loss, additional_losses=additional_losses)
+        return losses
+
+    def get_optimizer(self, config: Config) -> Dict[str, Optimizer]:
+        raise NotImplementedError

--- a/fl4health/clients/ensemble_client.py
+++ b/fl4health/clients/ensemble_client.py
@@ -95,7 +95,6 @@ class EnsembleClient(BasicClient):
         preds, features = self.predict(input)
         losses = self.compute_loss(preds, features, target)
 
-        assert isinstance(losses.backward, dict)
         for loss in losses.backward.values():
             loss.backward()
 

--- a/fl4health/clients/instance_level_privacy_client.py
+++ b/fl4health/clients/instance_level_privacy_client.py
@@ -61,11 +61,13 @@ class InstanceLevelPrivacyClient(BasicClient):
         # Create DP training objects
         privacy_engine = PrivacyEngine()
         # NOTE: that Opacus make private is NOT idempotent
-        self.model, self.optimizer, self.train_loader = privacy_engine.make_private(
+        self.model, optimizer, self.train_loader = privacy_engine.make_private(
             module=self.model,
-            optimizer=self.optimizer,
+            optimizer=self.optimizers["global"],
             data_loader=self.train_loader,
             noise_multiplier=self.noise_multiplier,
             max_grad_norm=self.clipping_bound,
             clipping="flat",
         )
+
+        self.optimizers = {"global": optimizer}

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -206,6 +206,18 @@ class ScaffoldClient(BasicClient):
         """
         self.update_control_variates(local_steps)
 
+    def setup_client(self, config: Config) -> None:
+        """
+        Set dataloaders, optimizers, parameter exchangers and other attributes derived from these.
+        Then set initialized attribute to True. Extends the basic client to extract the learning rate
+        from the optimizer and set the learning_rate attribute (used to compute updated control variates).
+
+        Args:
+            config (Config): The config from the server.
+        """
+        super().setup_client(config)
+        self.learning_rate = self.optimizers["global"].defaults["lr"]
+
 
 class DPScaffoldClient(ScaffoldClient, InstanceLevelPrivacyClient):  # type: ignore
     """

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -186,6 +186,7 @@ class ScaffoldClient(BasicClient):
         losses = self.compute_loss(preds, features, target)
 
         # Calculate backward pass, modify grad to account for client drift, update params
+        assert isinstance(losses.backward, torch.Tensor)
         losses.backward.backward()
         self.modify_grad()
         self.optimizers["global"].step()

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -45,6 +45,7 @@ class ScaffoldClient(BasicClient):
         self.client_control_variates: Optional[NDArrays] = None  # c_i in paper
         self.client_control_variates_updates: Optional[NDArrays] = None  # delta_c_i in paper
         self.server_control_variates: Optional[NDArrays] = None  # c in paper
+        # Scaffold require vanilla SGD as optimizer
         self.optimizers: Dict[str, torch.optim.SGD]  # type: ignore
         self.server_model_weights: Optional[NDArrays] = None  # x in paper
         self.parameter_exchanger: ParameterExchangerWithPacking[NDArrays]

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -188,8 +188,7 @@ class ScaffoldClient(BasicClient):
         losses = self.compute_loss(preds, features, target)
 
         # Calculate backward pass, modify grad to account for client drift, update params
-        assert isinstance(losses.backward, torch.Tensor)
-        losses.backward.backward()
+        losses.backward["backward"].backward()
         self.modify_grad()
         self.optimizers["global"].step()
 

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from typing import Dict, Optional, Sequence
+
+import torch
+import torch.nn as nn
+
+
+class EnsembleAggregationMode(Enum):
+    VOTE = "VOTE"
+    AVERAGE = "AVERAGE"
+
+
+class EnsembleModel(nn.Module):
+    def __init__(
+        self,
+        models: Sequence[nn.Module],
+        aggregation_mode: Optional[EnsembleAggregationMode] = EnsembleAggregationMode.AVERAGE,
+    ) -> None:
+        super().__init__()
+        self.models = models
+        self.aggregation_mode = aggregation_mode
+
+    def forward(self, input: torch.Tensor) -> Dict[str, torch.Tensor]:
+        preds = {}
+        for i, model in enumerate(self.models):
+            preds[f"ensemble-model-{str(i)}"] = model(input).squeeze()
+
+        if self.aggregation_mode == EnsembleAggregationMode.AVERAGE:
+            ensemble_pred = self.ensemble_average(preds)
+        else:
+            ensemble_pred = self.ensemble_vote(preds)
+
+        preds["ensemble-pred"] = ensemble_pred
+
+        return preds
+
+    def ensemble_vote(self, model_preds: Dict[str, torch.Tensor]) -> torch.Tensor:
+        argmax_per_model = torch.stack([torch.argmax(val, dim=1) for val in model_preds.values()])
+        argmax = torch.max(argmax_per_model, dim=0)[0]
+        vote_preds = nn.functional.one_hot(argmax, num_classes=model_preds["ensemble-model-0"].shape[-1])
+        return vote_preds
+
+    def ensemble_average(self, model_preds: Dict[str, torch.Tensor]) -> torch.Tensor:
+        stacked_model_preds = torch.stack(list(model_preds.values()))
+        avg_preds = torch.mean(stacked_model_preds, dim=0)
+        return avg_preds

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -13,13 +13,17 @@ class EnsembleAggregationMode(Enum):
 class EnsembleModel(nn.Module):
     def __init__(
         self,
-        models: Dict[str, nn.Module],
+        ensemble_models: Dict[str, nn.Module],
         aggregation_mode: Optional[EnsembleAggregationMode] = EnsembleAggregationMode.AVERAGE,
     ) -> None:
         super().__init__()
-        self.model_keys = list(models.keys())
+
+        # Set attribute for each model in ensemble (nn.Module won't pick up parameters if stored in data structure)
+        self.model_keys = list(ensemble_models.keys())
         for key in self.model_keys:
-            setattr(self, key, models[key])
+            if not key.isidentifier():
+                raise ValueError("Model name must be valid Python identifier.")
+            setattr(self, key, ensemble_models[key])
         self.aggregation_mode = aggregation_mode
 
     def forward(self, input: torch.Tensor) -> Dict[str, torch.Tensor]:

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -17,13 +17,15 @@ class EnsembleModel(nn.Module):
         aggregation_mode: Optional[EnsembleAggregationMode] = EnsembleAggregationMode.AVERAGE,
     ) -> None:
         super().__init__()
-        self.models = models
+        self.model_keys = list(models.keys())
+        for key in self.model_keys:
+            setattr(self, key, models[key])
         self.aggregation_mode = aggregation_mode
 
     def forward(self, input: torch.Tensor) -> Dict[str, torch.Tensor]:
         preds = {}
-        for key, model in self.models.items():
-            preds[key] = model(input).squeeze()
+        for key in self.model_keys:
+            preds[key] = getattr(self, key)(input).squeeze()
 
         if self.aggregation_mode == EnsembleAggregationMode.AVERAGE:
             ensemble_pred = self.ensemble_average(list(preds.values()))

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -23,11 +23,7 @@ class EnsembleModel(nn.Module):
         Args:
             ensemble_models (Dict[str, nn.Module]): A dictionary of models that make up the ensemble.
             aggregation_mode (Optional[EnsembleAggregationMode]): The mode in which to aggregate the
-                predictions of indivdual models.
-
-        Raises:
-            ValueError: Keys of the ensemble_dicts must be valid python identifiers.
-
+                predictions of individual models.
         """
         super().__init__()
 
@@ -49,7 +45,7 @@ class EnsembleModel(nn.Module):
         for key, model in self.ensemble_models.items():
             preds[key] = model(input)
 
-        # Don't store gradients of when computing ensemble predictions
+        # Don't store gradients when computing ensemble predictions
         with torch.no_grad():
             if self.aggregation_mode == EnsembleAggregationMode.AVERAGE:
                 ensemble_pred = self.ensemble_average(list(preds.values()))

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
 import torch
 import torch.nn as nn
@@ -26,25 +26,32 @@ class EnsembleModel(nn.Module):
             preds[f"ensemble-model-{str(i)}"] = model(input).squeeze()
 
         if self.aggregation_mode == EnsembleAggregationMode.AVERAGE:
-            ensemble_pred = self.ensemble_average(preds)
+            ensemble_pred = self.ensemble_average(list(preds.values()))
         else:
-            ensemble_pred = self.ensemble_vote(preds)
+            ensemble_pred = self.ensemble_vote(list(preds.values()))
 
         preds["ensemble-pred"] = ensemble_pred
 
         return preds
 
-    def ensemble_vote(self, model_preds: Dict[str, torch.Tensor]) -> torch.Tensor:
-        argmax_per_model = torch.hstack([torch.argmax(val, dim=-1, keepdim=True) for val in model_preds.values()])
+    def ensemble_vote(self, preds_list: List[torch.Tensor]) -> torch.Tensor:
+        assert all(preds.shape == preds_list[0].shape for preds in preds_list)
+        preds_dimension = list(preds_list[0].shape)
+
+        if len(preds_dimension) > 2:
+            preds_list = [preds.reshape(-1, preds_dimension[-1]) for preds in preds_list]
+
+        argmax_per_model = torch.hstack([torch.argmax(preds, dim=1, keepdim=True) for preds in preds_list])
         index_count_list = map(lambda x: torch.unique(x, return_counts=True), argmax_per_model.unbind())
         indices_with_highest_counts = torch.tensor([index[torch.argmax(count)] for index, count in index_count_list])
-        vote_preds = nn.functional.one_hot(
-            indices_with_highest_counts, num_classes=model_preds["ensemble-model-0"].shape[-1]
-        )
+        vote_preds = nn.functional.one_hot(indices_with_highest_counts, num_classes=preds_dimension[-1])
+
+        if len(preds_dimension) > 2:
+            vote_preds = vote_preds.reshape(*preds_dimension)
 
         return vote_preds
 
-    def ensemble_average(self, model_preds: Dict[str, torch.Tensor]) -> torch.Tensor:
-        stacked_model_preds = torch.stack(list(model_preds.values()))
+    def ensemble_average(self, preds_list: List[torch.Tensor]) -> torch.Tensor:
+        stacked_model_preds = torch.stack(preds_list)
         avg_preds = torch.mean(stacked_model_preds, dim=0)
         return avg_preds

--- a/fl4health/model_bases/ensemble_base.py
+++ b/fl4health/model_bases/ensemble_base.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -13,7 +13,7 @@ class EnsembleAggregationMode(Enum):
 class EnsembleModel(nn.Module):
     def __init__(
         self,
-        models: Sequence[nn.Module],
+        models: Dict[str, nn.Module],
         aggregation_mode: Optional[EnsembleAggregationMode] = EnsembleAggregationMode.AVERAGE,
     ) -> None:
         super().__init__()
@@ -22,8 +22,8 @@ class EnsembleModel(nn.Module):
 
     def forward(self, input: torch.Tensor) -> Dict[str, torch.Tensor]:
         preds = {}
-        for i, model in enumerate(self.models):
-            preds[f"ensemble-model-{str(i)}"] = model(input).squeeze()
+        for key, model in self.models.items():
+            preds[key] = model(input).squeeze()
 
         if self.aggregation_mode == EnsembleAggregationMode.AVERAGE:
             ensemble_pred = self.ensemble_average(list(preds.values()))

--- a/fl4health/utils/losses.py
+++ b/fl4health/utils/losses.py
@@ -21,6 +21,8 @@ class Losses:
     def as_dict(self) -> Dict[str, float]:
         loss_dict: Dict[str, float] = {}
         loss_dict["checkpoint"] = float(self.checkpoint.item())
+
+        # backward loss can either be Tensor or dictionary of Tensors
         if isinstance(self.backward, dict):
             backward = {key: loss.item() for key, loss in self.backward.items()}
             loss_dict.update(backward)

--- a/fl4health/utils/losses.py
+++ b/fl4health/utils/losses.py
@@ -90,7 +90,7 @@ class LossMeter(ABC):
         Compute aggregation of current list of losses if non-empty.
 
         Returns:
-            Losses: New Losses object with average of losses in losses_list.
+            Losses: New Losses object with aggregate of losses in losses_list.
 
         Raises:
             NotImplentedError: To be impemented by child class.

--- a/fl4health/utils/losses.py
+++ b/fl4health/utils/losses.py
@@ -13,21 +13,38 @@ class Losses:
         checkpoint: torch.Tensor,
         backward: Union[torch.Tensor, Dict[str, torch.Tensor]],
         additional_losses: Optional[Dict[str, torch.Tensor]] = None,
-    ):
+    ) -> None:
+        """
+        A class to store the checkpoint, backward and additional_losses of a model
+        along with a method to return a dictionary representation.
+
+        Args:
+            checkpoint (torch.Tensor): The loss used to checkpoint model (if checkpointing is enabled).
+            backward (Union[torch.Tensor, Dict[str, torch.Tensor]]): The backward loss or
+                losses to optimize. In the normal case, backward is a Tensor corresponding to the
+                loss of a model. In the case of an ensemble_model, backward is dictionary of losses.
+        """
         self.checkpoint = checkpoint
         self.backward = backward
         self.additional_losses = additional_losses if additional_losses else {}
 
     def as_dict(self) -> Dict[str, float]:
+        """
+        Produces a dictionary representation of the object with all of the losses.
+
+        Returns:
+            Dict[str, float]: A dictionary where each key represents one of the checkpoint,
+                backward or additional losses.
+        """
         loss_dict: Dict[str, float] = {}
         loss_dict["checkpoint"] = float(self.checkpoint.item())
 
         # backward loss can either be Tensor or dictionary of Tensors
         if isinstance(self.backward, dict):
-            backward = {key: loss.item() for key, loss in self.backward.items()}
+            backward = {key: float(loss.item()) for key, loss in self.backward.items()}
             loss_dict.update(backward)
         else:
-            loss_dict.update({"backward": self.backward.item()})
+            loss_dict.update({"backward": float(self.backward.item())})
 
         if self.additional_losses is not None:
             for key, val in self.additional_losses.items():

--- a/fl4health/utils/losses.py
+++ b/fl4health/utils/losses.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import torch
 
@@ -23,9 +23,10 @@ class Losses:
             backward (Union[torch.Tensor, Dict[str, torch.Tensor]]): The backward loss or
                 losses to optimize. In the normal case, backward is a Tensor corresponding to the
                 loss of a model. In the case of an ensemble_model, backward is dictionary of losses.
+            additional_losses (Optional[Dict[str, torch.Tensor]]): Optional dictionary of additional losses.
         """
         self.checkpoint = checkpoint
-        self.backward = backward
+        self.backward = backward if isinstance(backward, dict) else {"backward": backward}
         self.additional_losses = additional_losses if additional_losses else {}
 
     def as_dict(self) -> Dict[str, float]:
@@ -39,12 +40,8 @@ class Losses:
         loss_dict: Dict[str, float] = {}
         loss_dict["checkpoint"] = float(self.checkpoint.item())
 
-        # backward loss can either be Tensor or dictionary of Tensors
-        if isinstance(self.backward, dict):
-            backward = {key: float(loss.item()) for key, loss in self.backward.items()}
-            loss_dict.update(backward)
-        else:
-            loss_dict.update({"backward": float(self.backward.item())})
+        backward = {key: float(loss.item()) for key, loss in self.backward.items()}
+        loss_dict.update(backward)
 
         if self.additional_losses is not None:
             for key, val in self.additional_losses.items():
@@ -58,21 +55,59 @@ class LossMeterType(Enum):
     ACCUMULATION = "ACCUMULATION"
 
 
+class LossType(Enum):
+    BACKWARD = "BACKWARD"
+    ADDITIONAL = "ADDITIONAL"
+
+
 class LossMeter(ABC):
     @abstractmethod
     def update(self, losses: Losses) -> None:
+        """
+        Appends loss to list of losses.
+
+        Args:
+            losses (Losses): A losses object with checkpoint, backward and additional losses.
+
+        Raises:
+            NotImplementedError: To be implented by child classes.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def clear(self) -> None:
+        """
+        Reset the meter by re-initializing losses_list to be empty
+
+        Raises:
+            NotImplementedError: To be implemented by child class.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def compute(self) -> Losses:
+        """
+        Compute aggregation of current list of losses if non-empty.
+
+        Returns:
+            Losses: New Losses object with average of losses in losses_list.
+
+        Raises:
+            NotImplentedError: To be impemented by child class.
+        """
         raise NotImplementedError
 
     @classmethod
     def get_meter_by_type(cls, meter_enum: LossMeterType) -> LossMeter:
+        """
+        Class method that returns LossMeter instance of given type.
+
+        Args:
+            meter_enum (LossMeterType): The type of loss meter to create.
+
+        Returns:
+            LossMeter: New LossMeter instance of given type.
+        """
         if meter_enum == LossMeterType.AVERAGE:
             return LossAverageMeter()
         elif meter_enum == LossMeterType.ACCUMULATION:
@@ -80,75 +115,123 @@ class LossMeter(ABC):
         else:
             raise ValueError(f"Not supported meter type: {str(meter_enum)}")
 
+    @classmethod
+    def aggregate_loss_by_type(
+        cls, losses_list: Sequence[Losses], loss_type: LossType, loss_meter_type: LossMeterType
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Class method that aggregates a loss by loss_type (ie backward, checkpoint, additional).
+
+        Args:
+            losses_list (Sequence[Losses]): List of losses to aggregate.
+            loss_type (LossType): The type of loss (ie backward or additional loss).
+            loss_meter_type (LossMeterType): The type of LossMeter (ie average or accumulation).
+
+        Returns:
+            Dict[str, torch.Tensor]: The dictionary of aggregated losses.
+        """
+
+        if loss_type == LossType.BACKWARD:
+            loss_list = [losses.backward for losses in losses_list]
+        else:
+            loss_list = [losses.additional_losses for losses in losses_list]
+
+        # We don't know the keys of the dict (backward or additional losses) beforehand. We obtain them
+        # from the first entry because we know all of the losses will have the same keys
+        loss_keys = loss_list[0].keys()
+        num_losses = len(loss_list)
+        loss_dict: Dict[str, torch.Tensor] = {}
+        for key in loss_keys:
+            loss = torch.sum(torch.FloatTensor([loss[key] for loss in loss_list]))
+            if loss_meter_type == LossMeterType.AVERAGE:
+                loss = loss / num_losses
+            loss_dict[key] = loss
+
+        return loss_dict
+
 
 class LossAverageMeter(LossMeter):
     def __init__(self) -> None:
+        """
+        A meter to store and aggregate losses via averaging.
+        """
         self.losses_list: List[Losses] = []
 
     def update(self, losses: Losses) -> None:
+        """
+        Appends loss to list of losses.
+
+        Args:
+            losses (Losses): A losses object with checkpoint, backward and additional losses.
+        """
         self.losses_list.append(losses)
 
     def clear(self) -> None:
+        """
+        Reset the meter by re-initializing losses_list to be empty
+        """
         self.losses_list = []
 
     def compute(self) -> Losses:
+        """
+        Compute average of current list of losses if non-empty.
+
+        Returns:
+            Losses: New Losses object with average of losses in losses_list.
+        """
         assert len(self.losses_list) > 0
 
         num_losses = len(self.losses_list)
         # Compute average checkpoint and backward losses across list
         checkpoint_loss = torch.sum(torch.FloatTensor([losses.checkpoint for losses in self.losses_list])) / num_losses
-        backward_loss: Union[torch.Tensor, Dict[str, torch.Tensor]]
-        if all(isinstance(losses.backward, dict) for losses in self.losses_list):
-            assert isinstance(self.losses_list[0].backward, dict)
-            backward_loss = {
-                key: torch.sum(
-                    torch.FloatTensor(
-                        [losses.backward[key] for losses in self.losses_list if isinstance(losses.backward, dict)]
-                    )
-                )
-                / num_losses
-                for key in self.losses_list[0].backward.keys()
-            }
-        else:
-            backward_loss = torch.sum(torch.FloatTensor([losses.backward for losses in self.losses_list])) / num_losses
-
-        # We don't know the keys of the additional_losses beforehand so we extract them from the first entry
-        # because we know all of the losses will have the same keys in additinal_losses dict
-        additional_losses: Dict[str, torch.Tensor] = {}
-        for key in self.losses_list[0].additional_losses.keys():
-            additional_losses[key] = (
-                torch.sum(torch.FloatTensor([losses.additional_losses[key] for losses in self.losses_list]))
-                / num_losses
-            )
-
-        losses = Losses(checkpoint=checkpoint_loss, backward=backward_loss, additional_losses=additional_losses)
+        backward_loss = LossMeter.aggregate_loss_by_type(
+            self.losses_list, loss_type=LossType.BACKWARD, loss_meter_type=LossMeterType.AVERAGE
+        )
+        additional_loss = LossMeter.aggregate_loss_by_type(
+            self.losses_list, loss_type=LossType.ADDITIONAL, loss_meter_type=LossMeterType.AVERAGE
+        )
+        losses = Losses(backward=backward_loss, checkpoint=checkpoint_loss, additional_losses=additional_loss)
         return losses
 
 
 class LossAccumulationMeter(LossMeter):
     def __init__(self) -> None:
+        """
+        A meter to store and aggregate losses via accumulation.
+        """
         self.losses_list: List[Losses] = []
 
     def update(self, losses: Losses) -> None:
+        """
+        Appends loss to list of losses.
+
+        Args:
+            losses (Losses): A losses object with checkpoint, backward and additional losses.
+        """
         self.losses_list.append(losses)
 
     def clear(self) -> None:
+        """
+        Reset the meter by re-initializing losses_list to be empty
+        """
         self.losses_list = []
 
     def compute(self) -> Losses:
+        """
+        Compute sum of current list of losses if non-empty.
+
+        Returns:
+            Losses: New Losses object with sum of losses in losses_list.
+        """
         assert len(self.losses_list) > 0
 
         # Compute average checkpoint and backward losses across list
         checkpoint_loss = torch.sum(torch.FloatTensor([losses.checkpoint for losses in self.losses_list]))
-        backward_loss = torch.sum(torch.FloatTensor([losses.backward for losses in self.losses_list]))
-
-        # We don't know the keys of the additional_losses beforehand so we extract them from the first entry
-        # because we know all of the losses will have the same keys in additinal_losses dict
-        additional_losses: Dict[str, torch.Tensor] = {}
-        for key in self.losses_list[0].additional_losses.keys():
-            additional_losses[key] = torch.sum(
-                torch.FloatTensor([losses.additional_losses[key] for losses in self.losses_list])
-            )
-
-        losses = Losses(checkpoint=checkpoint_loss, backward=backward_loss, additional_losses=additional_losses)
+        backward_loss = LossMeter.aggregate_loss_by_type(
+            self.losses_list, loss_type=LossType.BACKWARD, loss_meter_type=LossMeterType.ACCUMULATION
+        )
+        additional_loss = LossMeter.aggregate_loss_by_type(
+            self.losses_list, loss_type=LossType.ADDITIONAL, loss_meter_type=LossMeterType.ACCUMULATION
+        )
+        losses = Losses(backward=backward_loss, checkpoint=checkpoint_loss, additional_losses=additional_loss)
         return losses

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ black
 flake8
 flwr==1.4.0
 isort
+mock
 mypy
 nltk
 numpy

--- a/research/flamby/fed_heart_disease/apfl/client.py
+++ b/research/flamby/fed_heart_disease/apfl/client.py
@@ -46,7 +46,7 @@ class FedHeartDiseaseApflClient(ApflClient):
         )
         assert 0 <= client_number < NUM_CLIENTS
 
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         self.alpha_learning_rate = alpha_learning_rate
         self.client_number = client_number
 

--- a/research/flamby/fed_heart_disease/fedadam/client.py
+++ b/research/flamby/fed_heart_disease/fedadam/client.py
@@ -40,7 +40,7 @@ class FedHeartDiseaseFedAdamClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_heart_disease/fedavg/client.py
+++ b/research/flamby/fed_heart_disease/fedavg/client.py
@@ -40,7 +40,7 @@ class FedHeartDiseaseFedAvgClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_heart_disease/fedprox/client.py
+++ b/research/flamby/fed_heart_disease/fedprox/client.py
@@ -40,7 +40,7 @@ class FedHeartDiseaseFedProxClient(FedProxClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_heart_disease/fenda/client.py
+++ b/research/flamby/fed_heart_disease/fenda/client.py
@@ -48,7 +48,7 @@ class FedHeartDiseaseFendaClient(FendaClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         if cos_sim_activate:
             self.cos_sim_loss_weight = 100.0
         if contrastive_activate:

--- a/research/flamby/fed_heart_disease/moon/client.py
+++ b/research/flamby/fed_heart_disease/moon/client.py
@@ -41,7 +41,7 @@ class FedHeartDiseaseMoonClient(MoonClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_heart_disease/scaffold/client.py
+++ b/research/flamby/fed_heart_disease/scaffold/client.py
@@ -40,7 +40,7 @@ class FedHeartDiseaseScaffoldClient(ScaffoldClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_isic2019/apfl/client.py
+++ b/research/flamby/fed_isic2019/apfl/client.py
@@ -44,7 +44,7 @@ class FedIsic2019ApflClient(ApflClient):
         )
         assert 0 <= client_number < NUM_CLIENTS
 
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         self.alpha_learning_rate = alpha_learning_rate
         self.client_number = client_number
 

--- a/research/flamby/fed_isic2019/fedadam/client.py
+++ b/research/flamby/fed_isic2019/fedadam/client.py
@@ -41,7 +41,7 @@ class FedIsic2019FedAdamClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_isic2019/fedavg/client.py
+++ b/research/flamby/fed_isic2019/fedavg/client.py
@@ -40,7 +40,7 @@ class FedIsic2019FedAvgClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_isic2019/fedprox/client.py
+++ b/research/flamby/fed_isic2019/fedprox/client.py
@@ -40,7 +40,7 @@ class FedIsic2019FedProxClient(FedProxClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_isic2019/fenda/client.py
+++ b/research/flamby/fed_isic2019/fenda/client.py
@@ -44,7 +44,7 @@ class FedIsic2019FendaClient(FendaClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         if cos_sim_activate:
             self.cos_sim_loss_weight = 100.0
         if contrastive_activate:

--- a/research/flamby/fed_isic2019/moon/client.py
+++ b/research/flamby/fed_isic2019/moon/client.py
@@ -41,7 +41,7 @@ class FedIsic2019MoonClient(MoonClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_isic2019/scaffold/client.py
+++ b/research/flamby/fed_isic2019/scaffold/client.py
@@ -40,7 +40,7 @@ class FedIsic2019ScaffoldClient(ScaffoldClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_ixi/apfl/client.py
+++ b/research/flamby/fed_ixi/apfl/client.py
@@ -48,7 +48,7 @@ class FedIxiApflClient(ApflClient):
         )
         assert 0 <= client_number < NUM_CLIENTS
 
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         self.alpha_learning_rate = alpha_learning_rate
         self.client_number = client_number
 

--- a/research/flamby/fed_ixi/fedadam/client.py
+++ b/research/flamby/fed_ixi/fedadam/client.py
@@ -41,7 +41,7 @@ class FedIxiFedAdamClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_ixi/fedavg/client.py
+++ b/research/flamby/fed_ixi/fedavg/client.py
@@ -40,7 +40,7 @@ class FedIxiFedAvgClient(BasicClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_ixi/fedprox/client.py
+++ b/research/flamby/fed_ixi/fedprox/client.py
@@ -40,7 +40,7 @@ class FedIxiFedProxClient(FedProxClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_ixi/fenda/client.py
+++ b/research/flamby/fed_ixi/fenda/client.py
@@ -48,7 +48,7 @@ class FedIxiFendaClient(FendaClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
         if cos_sim_activate:
             self.cos_sim_loss_weight = 100.0
         if contrastive_activate:

--- a/research/flamby/fed_ixi/moon/client.py
+++ b/research/flamby/fed_ixi/moon/client.py
@@ -41,7 +41,7 @@ class FedIxiMoonClient(MoonClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/research/flamby/fed_ixi/scaffold/client.py
+++ b/research/flamby/fed_ixi/scaffold/client.py
@@ -40,7 +40,7 @@ class FedIxiScaffoldClient(ScaffoldClient):
             checkpointer=checkpointer,
         )
         self.client_number = client_number
-        self.learning_rate = learning_rate
+        self.learning_rate: float = learning_rate
 
         assert 0 <= client_number < NUM_CLIENTS
         log(INFO, f"Client Name: {self.client_name}, Client Number: {self.client_number}")

--- a/tests/clients/fixtures.py
+++ b/tests/clients/fixtures.py
@@ -51,7 +51,7 @@ def get_client(type: type, model: nn.Module) -> BasicClient:
         raise ValueError(f"{str(type)} is not a valid client type")
 
     client.model = model
-    client.optimizer = torch.optim.SGD(client.model.parameters(), lr=0.0001)  # type: ignore
+    client.optimizers = {"global": torch.optim.SGD(client.model.parameters(), lr=0.0001)}  # type: ignore
     client.train_loader = DataLoader(TensorDataset(torch.ones((1000, 28, 28, 1)), torch.ones((1000))))  # type: ignore
     client.initialized = True
     return client

--- a/tests/clients/test_fed_prox_client.py
+++ b/tests/clients/test_fed_prox_client.py
@@ -139,6 +139,6 @@ def test_compute_loss(get_client: FedProxClient) -> None:  # noqa
     preds = {"prediction": torch.tensor([[1.0, 0.0], [0.0, 1.0]])}
     target = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
     loss = fed_prox_client.compute_loss(preds, {}, target)
-
+    assert isinstance(loss.backward, torch.Tensor)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
     assert loss.checkpoint.item() != loss.backward.item()

--- a/tests/clients/test_fed_prox_client.py
+++ b/tests/clients/test_fed_prox_client.py
@@ -139,6 +139,6 @@ def test_compute_loss(get_client: FedProxClient) -> None:  # noqa
     preds = {"prediction": torch.tensor([[1.0, 0.0], [0.0, 1.0]])}
     target = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
     loss = fed_prox_client.compute_loss(preds, {}, target)
-    assert isinstance(loss.backward, torch.Tensor)
+    assert isinstance(loss.backward, dict)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
-    assert loss.checkpoint.item() != loss.backward.item()
+    assert loss.checkpoint.item() != loss.backward["backward"].item()

--- a/tests/clients/test_fenda_client.py
+++ b/tests/clients/test_fenda_client.py
@@ -86,7 +86,7 @@ def test_computing_loss(get_fenda_client: FendaClient) -> None:  # noqa
         "aggregated_global_features": aggregated_global_features,
     }
     loss = fenda_client.compute_loss(preds=preds, target=target, features=features)
-
+    assert isinstance(loss.backward, torch.Tensor)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
     assert loss.checkpoint.item() != loss.backward.item()
 

--- a/tests/clients/test_fenda_client.py
+++ b/tests/clients/test_fenda_client.py
@@ -86,11 +86,11 @@ def test_computing_loss(get_fenda_client: FendaClient) -> None:  # noqa
         "aggregated_global_features": aggregated_global_features,
     }
     loss = fenda_client.compute_loss(preds=preds, target=target, features=features)
-    assert isinstance(loss.backward, torch.Tensor)
+    assert isinstance(loss.backward["backward"], torch.Tensor)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
-    assert loss.checkpoint.item() != loss.backward.item()
+    assert loss.checkpoint.item() != loss.backward["backward"].item()
 
-    auxiliary_loss_total = (loss.backward - loss.checkpoint).item()
+    auxiliary_loss_total = (loss.backward["backward"] - loss.checkpoint).item()
     contrastive_minimize = loss.additional_losses["contrastive_loss_minimize"].item()
     contrastive_maximize = loss.additional_losses["contrastive_loss_maximize"].item()
     assert pytest.approx(auxiliary_loss_total, abs=0.001) == (contrastive_minimize + contrastive_maximize)

--- a/tests/clients/test_instance_level.py
+++ b/tests/clients/test_instance_level.py
@@ -14,5 +14,5 @@ def test_instance_level_client(get_client: InstanceLevelPrivacyClient) -> None: 
     client.setup_opacus_objects()
 
     assert isinstance(client.model, GradSampleModule)
-    assert isinstance(client.optimizer, DPOptimizer)
+    assert isinstance(client.optimizers["global"], DPOptimizer)
     assert isinstance(client.train_loader, DataLoader)

--- a/tests/clients/test_moon_client.py
+++ b/tests/clients/test_moon_client.py
@@ -69,7 +69,7 @@ def test_compute_loss(get_client: MoonClient) -> None:  # noqa
     }
 
     loss = moon_client.compute_loss(preds=preds, features=features, target=target)
-    assert isinstance(loss.backward, torch.Tensor)
+    assert isinstance(loss.backward["backward"], torch.Tensor)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
     assert pytest.approx(0.837868, abs=0.0001) == loss.additional_losses["contrastive_loss"]
-    assert pytest.approx(0.837868 + 0.8132616, abs=0.0001) == loss.backward.item()
+    assert pytest.approx(0.837868 + 0.8132616, abs=0.0001) == loss.backward["backward"].item()

--- a/tests/clients/test_moon_client.py
+++ b/tests/clients/test_moon_client.py
@@ -69,7 +69,7 @@ def test_compute_loss(get_client: MoonClient) -> None:  # noqa
     }
 
     loss = moon_client.compute_loss(preds=preds, features=features, target=target)
-
+    assert isinstance(loss.backward, torch.Tensor)
     assert pytest.approx(0.8132616, abs=0.0001) == loss.checkpoint.item()
     assert pytest.approx(0.837868, abs=0.0001) == loss.additional_losses["contrastive_loss"]
     assert pytest.approx(0.837868 + 0.8132616, abs=0.0001) == loss.backward.item()

--- a/tests/clients/test_scaffold_client.py
+++ b/tests/clients/test_scaffold_client.py
@@ -56,7 +56,7 @@ def test_dp_scaffold_client(get_client: DPScaffoldClient) -> None:  # noqa
     client.setup_opacus_objects()
 
     assert isinstance(client.model, GradSampleModule)
-    assert isinstance(client.optimizer, DPOptimizer)
+    assert isinstance(client.optimizers["global"], DPOptimizer)
     assert isinstance(client.train_loader, DataLoader)
 
     assert hasattr(client, "client_control_variates")

--- a/tests/clients/test_setup_client_basic.py
+++ b/tests/clients/test_setup_client_basic.py
@@ -40,5 +40,4 @@ def test_setup_client() -> None:
     assert client.val_loader is not None
     assert client.num_train_samples is not None
     assert client.num_val_samples is not None
-    assert client.learning_rate is not None
     assert client.initialized

--- a/tests/clients/test_setup_client_basic.py
+++ b/tests/clients/test_setup_client_basic.py
@@ -35,7 +35,7 @@ def test_setup_client() -> None:
     client.setup_client({})
     assert client.parameter_exchanger is not None
     assert client.model is not None
-    assert client.optimizer is not None
+    assert client.optimizers is not None
     assert client.train_loader is not None
     assert client.val_loader is not None
     assert client.num_train_samples is not None

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -31,11 +31,34 @@ def test_forward_vote_mode() -> None:
 
 def test_ensemble_vote() -> None:
     fake_instance = mock.Mock()
-    tnsr = {
-        "ensemble-model-0": torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
-        "ensemble-model-1": torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
-        "ensemble-model-2": torch.tensor([[0.25, 0.5, 1.0], [1.0, 3.21, 0.2], [2.4, 0.5, 0.8]]),
-    }
-    ensemble_pred = EnsembleModel.ensemble_vote(fake_instance, tnsr)
+    tnsr_list = [
+        torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
+        torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
+        torch.tensor([[0.25, 0.5, 1.0], [1.0, 3.21, 0.2], [2.4, 0.5, 0.8]]),
+    ]
+    ensemble_pred = EnsembleModel.ensemble_vote(fake_instance, tnsr_list)
     gt_ensemble_pred = torch.tensor([[1, 0, 0], [0, 0, 1], [0, 0, 1]])
     assert torch.equal(ensemble_pred, gt_ensemble_pred)
+
+    tnsr_list2 = [
+        torch.tensor([[[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]] for _ in range(3)]),
+        torch.tensor([[[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]] for _ in range(3)]),
+        torch.tensor([[[0.25, 0.5, 1.0], [1.0, 3.21, 0.2], [2.4, 0.5, 0.8]] for _ in range(3)]),
+    ]
+
+    ensemble_pred2 = EnsembleModel.ensemble_vote(fake_instance, tnsr_list2)
+    gt_ensemble_pred2 = torch.tensor([[[1, 0, 0], [0, 0, 1], [0, 0, 1]] for _ in range(3)])
+    assert torch.equal(ensemble_pred2, gt_ensemble_pred2)
+
+
+def test_ensenble_average() -> None:
+    fake_instance = mock.Mock()
+    tnsr_list = [torch.eye(5) * (i + 1.0) for i in range(3)]
+    ensemble_pred = EnsembleModel.ensemble_average(fake_instance, tnsr_list)
+    gt_ensemble_pred = torch.eye(5) * 2.0
+    assert torch.equal(ensemble_pred, gt_ensemble_pred)
+
+    tnsr_list2 = [torch.ones((7, 7, 7)), torch.zeros((7, 7, 7)), torch.ones((7, 7, 7)), torch.zeros((7, 7, 7))]
+    ensemble_pred2 = EnsembleModel.ensemble_average(fake_instance, tnsr_list2)
+    gt_ensemble_pred2 = torch.ones((7, 7, 7)) * 0.5
+    assert torch.equal(ensemble_pred2, gt_ensemble_pred2)

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -1,10 +1,11 @@
+import mock
 import torch
 
 from fl4health.model_bases.ensemble_base import EnsembleAggregationMode, EnsembleModel
 from tests.test_utils.models_for_test import SmallCnn
 
 
-def test_ensemble_model_average_mode() -> None:
+def test_forward_average_mode() -> None:
     models = [SmallCnn(), SmallCnn()]
     em = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
     data = torch.rand((64, 1, 28, 28))
@@ -15,13 +16,8 @@ def test_ensemble_model_average_mode() -> None:
     assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
     assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
 
-    gt_ensemble_pred = torch.mean(
-        torch.stack([val for key, val in ep.items() if key in ["ensemble-model-0", "ensemble-model-1"]]), dim=0
-    )
-    assert torch.equal(gt_ensemble_pred, ep["ensemble-pred"])
 
-
-def test_ensemble_model_vote_mode() -> None:
+def test_forward_vote_mode() -> None:
     models = [SmallCnn(), SmallCnn()]
     em = EnsembleModel(models, EnsembleAggregationMode.VOTE)
     data = torch.rand((64, 1, 28, 28))
@@ -31,3 +27,15 @@ def test_ensemble_model_vote_mode() -> None:
     assert "ensemble-model-0" in ep and ep["ensemble-model-0"].shape == torch.Size([64, 32])
     assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
     assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
+
+
+def test_ensemble_vote() -> None:
+    fake_instance = mock.Mock()
+    tnsr = {
+        "ensemble-model-0": torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
+        "ensemble-model-1": torch.tensor([[1.0, 0.5, 0.25], [0.25, 0.33, 0.89], [0.2, 0.4, 0.8]]),
+        "ensemble-model-2": torch.tensor([[0.25, 0.5, 1.0], [1.0, 3.21, 0.2], [2.4, 0.5, 0.8]]),
+    }
+    ensemble_pred = EnsembleModel.ensemble_vote(fake_instance, tnsr)
+    gt_ensemble_pred = torch.tensor([[1, 0, 0], [0, 0, 1], [0, 0, 1]])
+    assert torch.equal(ensemble_pred, gt_ensemble_pred)

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -1,0 +1,33 @@
+import torch
+
+from fl4health.model_bases.ensemble_base import EnsembleAggregationMode, EnsembleModel
+from tests.test_utils.models_for_test import SmallCnn
+
+
+def test_ensemble_model_average_mode() -> None:
+    models = [SmallCnn(), SmallCnn()]
+    em = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
+    data = torch.rand((64, 1, 28, 28))
+    ep = em(data)
+
+    assert len(ep) == 3
+    assert "ensemble-model-0" in ep and ep["ensemble-model-0"].shape == torch.Size([64, 32])
+    assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
+    assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
+
+    gt_ensemble_pred = torch.mean(
+        torch.stack([val for key, val in ep.items() if key in ["ensemble-model-0", "ensemble-model-1"]]), dim=0
+    )
+    assert torch.equal(gt_ensemble_pred, ep["ensemble-pred"])
+
+
+def test_ensemble_model_vote_mode() -> None:
+    models = [SmallCnn(), SmallCnn()]
+    em = EnsembleModel(models, EnsembleAggregationMode.VOTE)
+    data = torch.rand((64, 1, 28, 28))
+    ep = em(data)
+
+    assert len(ep) == 3
+    assert "ensemble-model-0" in ep and ep["ensemble-model-0"].shape == torch.Size([64, 32])
+    assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
+    assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -9,26 +9,26 @@ from tests.test_utils.models_for_test import SmallCnn
 
 
 def test_forward_average_mode() -> None:
-    models: Dict[str, nn.Module] = {"ensemble-model-0": SmallCnn(), "ensemble-model-1": SmallCnn()}
+    models: Dict[str, nn.Module] = {"model_0": SmallCnn(), "model_1": SmallCnn()}
     em = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
     data = torch.rand((64, 1, 28, 28))
     ep = em(data)
 
     assert len(ep) == 3
-    assert "ensemble-model-0" in ep and ep["ensemble-model-0"].shape == torch.Size([64, 32])
-    assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
+    assert "model_0" in ep and ep["model_1"].shape == torch.Size([64, 32])
+    assert "model_0" in ep and ep["model_1"].shape == torch.Size([64, 32])
     assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
 
 
 def test_forward_vote_mode() -> None:
-    models: Dict[str, nn.Module] = {"ensemble-model-0": SmallCnn(), "ensemble-model-1": SmallCnn()}
+    models: Dict[str, nn.Module] = {"model_0": SmallCnn(), "model_1": SmallCnn()}
     em = EnsembleModel(models, EnsembleAggregationMode.VOTE)
     data = torch.rand((64, 1, 28, 28))
     ep = em(data)
 
     assert len(ep) == 3
-    assert "ensemble-model-0" in ep and ep["ensemble-model-0"].shape == torch.Size([64, 32])
-    assert "ensemble-model-1" in ep and ep["ensemble-model-1"].shape == torch.Size([64, 32])
+    assert "model_0" in ep and ep["model_0"].shape == torch.Size([64, 32])
+    assert "model_1" in ep and ep["model_0"].shape == torch.Size([64, 32])
     assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
 
 

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -1,12 +1,15 @@
+from typing import Dict
+
 import mock
 import torch
+import torch.nn as nn
 
 from fl4health.model_bases.ensemble_base import EnsembleAggregationMode, EnsembleModel
 from tests.test_utils.models_for_test import SmallCnn
 
 
 def test_forward_average_mode() -> None:
-    models = [SmallCnn(), SmallCnn()]
+    models: Dict[str, nn.Module] = {"ensemble-model-0": SmallCnn(), "ensemble-model-1": SmallCnn()}
     em = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
     data = torch.rand((64, 1, 28, 28))
     ep = em(data)
@@ -18,7 +21,7 @@ def test_forward_average_mode() -> None:
 
 
 def test_forward_vote_mode() -> None:
-    models = [SmallCnn(), SmallCnn()]
+    models: Dict[str, nn.Module] = {"ensemble-model-0": SmallCnn(), "ensemble-model-1": SmallCnn()}
     em = EnsembleModel(models, EnsembleAggregationMode.VOTE)
     data = torch.rand((64, 1, 28, 28))
     ep = em(data)

--- a/tests/models/test_ensemble_base.py
+++ b/tests/models/test_ensemble_base.py
@@ -10,26 +10,30 @@ from tests.test_utils.models_for_test import SmallCnn
 
 def test_forward_average_mode() -> None:
     models: Dict[str, nn.Module] = {"model_0": SmallCnn(), "model_1": SmallCnn()}
-    em = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
+    ensemble_model = EnsembleModel(models, EnsembleAggregationMode.AVERAGE)
     data = torch.rand((64, 1, 28, 28))
-    ep = em(data)
+    ensemble_predictions = ensemble_model(data)
 
-    assert len(ep) == 3
-    assert "model_0" in ep and ep["model_1"].shape == torch.Size([64, 32])
-    assert "model_0" in ep and ep["model_1"].shape == torch.Size([64, 32])
-    assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
+    assert len(ensemble_predictions) == 3
+    assert "model_0" in ensemble_predictions and ensemble_predictions["model_0"].shape == torch.Size([64, 32])
+    assert "model_1" in ensemble_predictions and ensemble_predictions["model_1"].shape == torch.Size([64, 32])
+    assert "ensemble-pred" in ensemble_predictions and ensemble_predictions["ensemble-pred"].shape == torch.Size(
+        [64, 32]
+    )
 
 
 def test_forward_vote_mode() -> None:
     models: Dict[str, nn.Module] = {"model_0": SmallCnn(), "model_1": SmallCnn()}
-    em = EnsembleModel(models, EnsembleAggregationMode.VOTE)
+    ensemble_model = EnsembleModel(models, EnsembleAggregationMode.VOTE)
     data = torch.rand((64, 1, 28, 28))
-    ep = em(data)
+    ensemble_predictions = ensemble_model(data)
 
-    assert len(ep) == 3
-    assert "model_0" in ep and ep["model_0"].shape == torch.Size([64, 32])
-    assert "model_1" in ep and ep["model_0"].shape == torch.Size([64, 32])
-    assert "ensemble-pred" in ep and ep["ensemble-pred"].shape == torch.Size([64, 32])
+    assert len(ensemble_predictions) == 3
+    assert "model_0" in ensemble_predictions and ensemble_predictions["model_0"].shape == torch.Size([64, 32])
+    assert "model_1" in ensemble_predictions and ensemble_predictions["model_1"].shape == torch.Size([64, 32])
+    assert "ensemble-pred" in ensemble_predictions and ensemble_predictions["ensemble-pred"].shape == torch.Size(
+        [64, 32]
+    )
 
 
 def test_ensemble_vote() -> None:

--- a/tests/smoke_tests/client_level_dp_weighted_config.yaml
+++ b/tests/smoke_tests/client_level_dp_weighted_config.yaml
@@ -1,5 +1,5 @@
 # Server parameters
-n_server_rounds: 3
+n_server_rounds: 2
 
 # NOTE: This multiplier is small, yielding a vacuous epsilon for privacy. It is set to this small value for this
 # example due to the small number of clients (3, see below), which, when combined with the clipping implies that

--- a/tests/smoke_tests/ensemble_config.yaml
+++ b/tests/smoke_tests/ensemble_config.yaml
@@ -1,8 +1,8 @@
 # Parameters that describe server
-n_server_rounds: 5 # The number of rounds to run FL
+n_server_rounds: 2 # The number of rounds to run FL
 
 # Parameters that describe clients
-n_clients: 3 # The number of clients in the FL experiment
+n_clients: 2 # The number of clients in the FL experiment
 local_epochs: 1 # The number of epochs to complete for client
-batch_size: 128 # The batch size for client training
+batch_size: 32 # The batch size for client training
 sample_percentage: 0.75 # Determines relatives size of modified dataset

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -408,4 +408,12 @@ if __name__ == "__main__":
             dataset_path="examples/datasets/mnist_data/",
         )
     )
+    loop.run_until_complete(
+        run_smoke_test(
+            server_python_path="examples.ensemble_example.server",
+            client_python_path="examples.ensemble_example.client",
+            config_path="tests/smoke_tests/ensemble_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+        )
+    )
     loop.close()

--- a/tests/utils/losses_test.py
+++ b/tests/utils/losses_test.py
@@ -84,7 +84,7 @@ def test_loss_accumulation_meter() -> None:
     assert loss_dict["extra_loss"] == pytest.approx(22.0372, rel=0.01)
 
 
-def test_losses_with_mutliple_backward() -> None:
+def test_losses_with_multiple_backward() -> None:
     checkpoint = torch.tensor(4.4930, dtype=torch.float)
     backward_losses_dict = {
         "model-0": torch.tensor(4.1020, dtype=torch.float),

--- a/tests/utils/losses_test.py
+++ b/tests/utils/losses_test.py
@@ -82,3 +82,19 @@ def test_loss_accumulation_meter() -> None:
     assert loss_dict["checkpoint"] == pytest.approx(15.4639, rel=0.01)
     assert loss_dict["backward"] == pytest.approx(19.1791, rel=0.01)
     assert loss_dict["extra_loss"] == pytest.approx(22.0372, rel=0.01)
+
+
+def test_losses_with_mutliple_backward() -> None:
+    checkpoint = torch.tensor(4.4930, dtype=torch.float)
+    backward_losses_dict = {
+        "model-0": torch.tensor(4.1020, dtype=torch.float),
+        "model-1": torch.tensor(6.1020, dtype=torch.float),
+        "model-2": torch.tensor(8.1020, dtype=torch.float),
+    }
+    losses = Losses(checkpoint=checkpoint, backward=backward_losses_dict)
+    losses_dict = losses.as_dict()
+    assert losses_dict["model-0"] == pytest.approx(4.1020, rel=0.01)
+    assert losses_dict["model-1"] == pytest.approx(6.1020, rel=0.01)
+    assert losses_dict["model-2"] == pytest.approx(8.1020, rel=0.01)
+    assert losses_dict["checkpoint"] == pytest.approx(4.4930, rel=0.01)
+    assert len(losses_dict) == 4


### PR DESCRIPTION
# PR Type
[**Feature** | Fix | Documentation | Other ]

# Short Description

Clickup Ticket(s): [Federated training ensemble of models](https://app.clickup.com/t/8686ja6he)

Small PR that adds some initial functionality to support training ensembles of models in a federated manner. To this end, I added two classes: 
- `EnsembleModel`: A nn.Module that acts as a wrapper for the ensemble of models with support to produce predictions for individual models as well as an ensemble prediction via voting or averaging.
- `EnsembleClient`: A custom client to handle specific details of training a federated ensemble of models such as setting up the client, computing losses and performing a train step. 

In the process I had to make some minor changes to the `BasicClient` such as store client optimizers in a dictionary  and making the backward attribute of `Losses` a union of Tensor and a dictionary of Tensors. 

It is worth mentioning that I plan on doing a follow up PR that makes it so that we can use Ensembling in conjunction with other client types (ie Scaffold). This seems like a good first start and it would be good to get some eyes on it before I go further. 

# Tests Added
- Add tests to ensure the `EnsembleModel` produces predictions of the current dimension
- Add tests to ensure the "ensemble prediction methods" (ie voting and averaging) work correctly
- A small addition to the tests on `Losses` focused on the new functionality I mentioned 
