### PR TITLE
Upgrading jinja2 to 3.1.3 to fix a security issue

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1516,13 +1516,13 @@ testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

A security fix for `jinja2` has been released which solves the error by `pip-audit` in the CI check below. Here, I'm upgrading `jinja2` to the latest version.

https://github.com/VectorInstitute/FL4Health/actions/runs/7493390403

# Tests Added

NA
