### PR TITLE
Ignoring one more pillow 9.5.0 vulnerability

### DIFF
--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -50,3 +50,4 @@ jobs:
             PYSEC-2023-227
             GHSA-j7hp-h8jx-5ppr
             GHSA-56pw-mpj4-fxww
+            GHSA-3f63-hfp8-52jq


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

One more vulnerability has been found for Pillow 9.5.0 (https://github.com/advisories/GHSA-3f63-hfp8-52jq), ignoring it in `pip-audit` since we can't upgrade it right now.

# Tests Added

NA
