### PR TITLE
Relax Floating Point Number Tolerance for PCA test

### DIFF
--- a/fl4health/utils/random.py
+++ b/fl4health/utils/random.py
@@ -32,4 +32,4 @@ def unset_all_random_seeds() -> None:
     log(INFO, "Setting all random seeds to None.")
     random.seed(None)
     np.random.seed(None)
-    torch.manual_seed(None)
+    torch.seed()

--- a/fl4health/utils/random.py
+++ b/fl4health/utils/random.py
@@ -22,3 +22,14 @@ def set_all_random_seeds(seed: Optional[int] = 42) -> None:
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
+
+
+def unset_all_random_seeds() -> None:
+    """
+    Set random seeds for Python random, NumPy, and PyTorch to None. Running this function would undo
+    the effects of set_all_random_seeds.
+    """
+    log(INFO, "Setting all random seeds to None.")
+    random.seed(None)
+    np.random.seed(None)
+    torch.manual_seed(None)

--- a/tests/models/test_pca.py
+++ b/tests/models/test_pca.py
@@ -24,7 +24,7 @@ def setup_random_seeds() -> Generator[None, None, None]:
     unset_all_random_seeds()
 
 
-def create_full_rank_data(setup_random_seeds: None) -> Tensor:
+def create_full_rank_data(setup_random_seeds: Generator[None, None, None]) -> Tensor:
     # Create a full-rank data matrix of size (N, data_dimension).
     # Since torch.rand() is very likely to return a full-rank matrix,
     # we use it to achieve this (after setting seed).
@@ -33,7 +33,7 @@ def create_full_rank_data(setup_random_seeds: None) -> Tensor:
     return X
 
 
-def create_low_rank_data(setup_random_seeds: None) -> Tensor:
+def create_low_rank_data(setup_random_seeds: Generator[None, None, None]) -> Tensor:
     # Create a low-rank data matrix of size (N, data_dimension) and rank = low_rank.
     A = torch.rand(small_rank - 1, data_dimension)
     assert torch.linalg.matrix_rank(A) == small_rank - 1
@@ -58,7 +58,7 @@ def test_reshaping() -> None:
     assert (B == B_prime).all()
 
 
-def test_centering(setup_random_seeds: None) -> None:
+def test_centering(setup_random_seeds: Generator[None, None, None]) -> None:
     # Test that the pca module properly centers the data matrix.
     X = create_full_rank_data(setup_random_seeds)
     data_mean = torch.mean(X, dim=0)
@@ -70,7 +70,7 @@ def test_centering(setup_random_seeds: None) -> None:
     assert (pca_module.data_mean == data_mean).all()
 
 
-def test_full_svd_full_rank_data(setup_random_seeds: None) -> None:
+def test_full_svd_full_rank_data(setup_random_seeds: Generator[None, None, None]) -> None:
     pca_module = PcaModule(low_rank=False, full_svd=True)
     X = create_full_rank_data(setup_random_seeds)
     principal_components, singular_values = pca_module(X, center_data=True)
@@ -83,7 +83,7 @@ def test_full_svd_full_rank_data(setup_random_seeds: None) -> None:
     assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
-def test_full_svd_low_rank_data(setup_random_seeds: None) -> None:
+def test_full_svd_low_rank_data(setup_random_seeds: Generator[None, None, None]) -> None:
     pca_module = PcaModule(low_rank=False, full_svd=True)
     X = create_low_rank_data(setup_random_seeds)
     principal_components, singular_values = pca_module(X, center_data=True)
@@ -99,7 +99,7 @@ def test_full_svd_low_rank_data(setup_random_seeds: None) -> None:
     assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
-def test_reduced_svd_full_rank_data(setup_random_seeds: None) -> None:
+def test_reduced_svd_full_rank_data(setup_random_seeds: Generator[None, None, None]) -> None:
     pca_module = PcaModule(low_rank=False, full_svd=False)
     X = torch.rand(N_small, data_dimension)
     principal_components, singular_values = pca_module(X, center_data=True)
@@ -110,7 +110,7 @@ def test_reduced_svd_full_rank_data(setup_random_seeds: None) -> None:
     assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
-def test_reduced_svd_low_rank_data(setup_random_seeds: None) -> None:
+def test_reduced_svd_low_rank_data(setup_random_seeds: Generator[None, None, None]) -> None:
     pca_module = PcaModule(low_rank=False, full_svd=False)
     X = create_low_rank_data(setup_random_seeds)
     principal_components, singular_values = pca_module(X, center_data=True)
@@ -122,7 +122,7 @@ def test_reduced_svd_low_rank_data(setup_random_seeds: None) -> None:
     assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
-def test_low_rank_svd(setup_random_seeds: None) -> None:
+def test_low_rank_svd(setup_random_seeds: Generator[None, None, None]) -> None:
     # Following the same approach, we test the low_rank svd functionality.
     q = small_rank + 4
     pca_module = PcaModule(low_rank=True, full_svd=False, rank_estimation=q)

--- a/tests/models/test_pca.py
+++ b/tests/models/test_pca.py
@@ -80,7 +80,7 @@ def test_full_svd_low_rank_data() -> None:
     assert principal_components.size(1) == data_dimension and len(singular_values) == data_dimension
     # Since X is low-rank, it is expected that only the first small_rank singular values should be nonzero.
     # The remaining singular values should be (nearly) zero.
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=1e-5)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=5e-4)
     pca_module.set_principal_components(principal_components, singular_values)
 
     # Since X has rank = small_rank and this is also the number of principal components
@@ -105,7 +105,7 @@ def test_reduced_svd_low_rank_data() -> None:
     X = create_low_rank_data()
     principal_components, singular_values = pca_module(X, center_data=True)
     assert principal_components.size(1) == data_dimension and len(singular_values) == data_dimension
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=1e-5)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=5e-4)
     # We should still expect (nearly) perfect reconstruction.
     pca_module.set_principal_components(principal_components, singular_values)
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=small_rank, center_data=True)
@@ -119,7 +119,7 @@ def test_low_rank_svd() -> None:
     X = create_low_rank_data()
     principal_components, singular_values = pca_module(X, center_data=True)
     assert principal_components.size(1) == q and len(singular_values) == q
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(q - small_rank), atol=1e-5)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(q - small_rank), atol=5e-4)
     pca_module.set_principal_components(principal_components, singular_values)
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=small_rank, center_data=True)
     assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)

--- a/tests/models/test_pca.py
+++ b/tests/models/test_pca.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 from torch import Tensor
 
@@ -68,7 +70,7 @@ def test_full_svd_full_rank_data() -> None:
     # used in reconstruction equals this rank (since we perform full svd),
     # we should expect reconstruction_error to be close to zero.
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=None, center_data=True)
-    assert abs(reconstruction_error) < 1e-10
+    assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
 def test_full_svd_low_rank_data() -> None:
@@ -78,13 +80,13 @@ def test_full_svd_low_rank_data() -> None:
     assert principal_components.size(1) == data_dimension and len(singular_values) == data_dimension
     # Since X is low-rank, it is expected that only the first small_rank singular values should be nonzero.
     # The remaining singular values should be (nearly) zero.
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=5e-6)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=1e-5)
     pca_module.set_principal_components(principal_components, singular_values)
 
     # Since X has rank = small_rank and this is also the number of principal components
     # used in reconstruction, we should expect reconstruction_error to be close to zero.
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=small_rank, center_data=True)
-    assert abs(reconstruction_error) < 1e-10
+    assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
 def test_reduced_svd_full_rank_data() -> None:
@@ -95,7 +97,7 @@ def test_reduced_svd_full_rank_data() -> None:
     # We should still expect (nearly) perfect reconstruction.
     pca_module.set_principal_components(principal_components, singular_values)
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=None, center_data=True)
-    assert abs(reconstruction_error) < 1e-10
+    assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
 def test_reduced_svd_low_rank_data() -> None:
@@ -103,11 +105,11 @@ def test_reduced_svd_low_rank_data() -> None:
     X = create_low_rank_data()
     principal_components, singular_values = pca_module(X, center_data=True)
     assert principal_components.size(1) == data_dimension and len(singular_values) == data_dimension
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=5e-6)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(data_dimension - small_rank), atol=1e-5)
     # We should still expect (nearly) perfect reconstruction.
     pca_module.set_principal_components(principal_components, singular_values)
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=small_rank, center_data=True)
-    assert abs(reconstruction_error) < 1e-10
+    assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)
 
 
 def test_low_rank_svd() -> None:
@@ -117,7 +119,7 @@ def test_low_rank_svd() -> None:
     X = create_low_rank_data()
     principal_components, singular_values = pca_module(X, center_data=True)
     assert principal_components.size(1) == q and len(singular_values) == q
-    assert torch.allclose(singular_values[small_rank:], torch.zeros(q - small_rank), atol=5e-6)
+    assert torch.allclose(singular_values[small_rank:], torch.zeros(q - small_rank), atol=1e-5)
     pca_module.set_principal_components(principal_components, singular_values)
     reconstruction_error = pca_module.compute_reconstruction_error(X, k=small_rank, center_data=True)
-    assert abs(reconstruction_error) < 1e-10
+    assert math.isclose(reconstruction_error, 0.0, abs_tol=1e-8)

--- a/tests/models/test_pca.py
+++ b/tests/models/test_pca.py
@@ -11,13 +11,13 @@ N = 2048
 N_small = 128
 seed = 83
 small_rank = 16
-set_all_random_seeds(seed)
 
 
 def create_full_rank_data() -> Tensor:
     # Create a full-rank data matrix of size (N, data_dimension).
     # Since torch.rand() is very likely to return a full-rank matrix,
     # we use it to achieve this (after setting seed).
+    set_all_random_seeds(seed)
     X = torch.rand(N, data_dimension)
     assert torch.linalg.matrix_rank(X) == data_dimension
     return X
@@ -25,6 +25,7 @@ def create_full_rank_data() -> Tensor:
 
 def create_low_rank_data() -> Tensor:
     # Create a low-rank data matrix of size (N, data_dimension) and rank = low_rank.
+    set_all_random_seeds(seed)
     A = torch.rand(small_rank - 1, data_dimension)
     assert torch.linalg.matrix_rank(A) == small_rank - 1
     B = torch.ones(N - small_rank + 1, data_dimension)


### PR DESCRIPTION
# PR Type
[Fix]

Relaxed the floating point number tolerance used in `test_pca.py`.

# Tests Added

Updated `test_pca.py`
