### PR TITLE
add separate functions to clone model

### DIFF
--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -254,6 +254,8 @@ class BasicClient(NumPyClient):
 
         self.set_parameters(parameters, config)
 
+        self.update_before_train(current_server_round)
+
         if local_epochs is not None:
             loss_dict, metrics = self.train_by_epochs(local_epochs, current_server_round)
             local_steps = len(self.train_loader) * local_epochs  # total steps over training round
@@ -779,12 +781,22 @@ class BasicClient(NumPyClient):
         """
         raise NotImplementedError
 
+    def update_before_train(self, current_server_round: int) -> None:
+        """
+        Hook method called before strating training with the number of current server round performed.
+        For example, used by Moon and Fenda model and fenda to save global model after aggregation.
+
+        Args:
+            current_server_round (int): The number of current server round.
+        """
+        pass
+
     def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
         """
         Hook method called after training with the number of local_steps performed over the FL round and
         the corresponding loss dictionary. For example, used by Scaffold to update the control variates
         after a local round of training. Also used by FedProx to update the current loss based on the loss
-        returned during training.
+        returned during training. Also used to save previous train model weights by Moon and Fenda model.
 
         Args:
             local_steps (int): The number of steps in the local training.

--- a/tests/clients/test_fenda_client.py
+++ b/tests/clients/test_fenda_client.py
@@ -43,6 +43,92 @@ def test_getting_parameters(get_fenda_client: FendaClient) -> None:  # noqa
 
 
 @pytest.mark.parametrize("local_module,global_module,head_module", [(FeatureCnn(), FeatureCnn(), FendaHeadCnn())])
+def test_setting_global_model(get_client: FendaClient) -> None:  # noqa
+    torch.manual_seed(42)
+    fenda_client = get_client
+
+    assert fenda_client.aggregated_global_module is None
+    assert isinstance(fenda_client.model, FendaModel)
+
+    global_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.model.global_module.state_dict().items()
+    ]
+    fenda_client.update_before_train(0)
+
+    assert fenda_client.aggregated_global_module is not None
+
+    aggregate_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.aggregated_global_module.state_dict().items()
+    ]
+    # Make sure the fenda aggregated module parameters are equal to the global module parameters
+    for i in range(len(aggregate_params)):
+        assert (aggregate_params[i] == global_params[i]).all()
+
+    # Make sure the aggregated module is not set to train
+    assert fenda_client.aggregated_global_module.train is False
+    for param in fenda_client.aggregated_global_module.parameters():
+        assert param.requires_grad is False
+
+    # Make sure the original model is still set to train
+    assert fenda_client.model.train is True
+    for param in fenda_client.model.parameters():
+        assert param.requires_grad is True
+
+
+@pytest.mark.parametrize("local_module,global_module,head_module", [(FeatureCnn(), FeatureCnn(), FendaHeadCnn())])
+def test_setting_old_models(get_client: FendaClient) -> None:  # noqa
+    torch.manual_seed(42)
+    fenda_client = get_client
+
+    assert fenda_client.old_local_module is None
+    assert fenda_client.old_global_module is None
+    assert isinstance(fenda_client.model, FendaModel)
+
+    local_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.model.local_module.state_dict().items()
+    ]
+    global_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.model.global_module.state_dict().items()
+    ]
+    loss = {
+        "loss": 0.0,
+    }
+    fenda_client.update_after_train(0, loss)
+
+    assert fenda_client.old_local_module is not None
+    old_local_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.old_local_module.state_dict().items()
+    ]
+
+    assert fenda_client.old_global_module is not None
+    old_global_params = [
+        copy.deepcopy(val.cpu().numpy()) for _, val in fenda_client.old_global_module.state_dict().items()
+    ]
+
+    # Make sure the Fenda old local module parameters are equal to the local module parameters
+    for i in range(len(local_params)):
+        assert (local_params[i] == old_local_params[i]).all()
+
+    # Make sure the Fenda old global module parameters are equal to the global module parameters
+    for i in range(len(global_params)):
+        assert (global_params[i] == old_global_params[i]).all()
+
+    # Make sure the old global and local module is not set to train
+    assert fenda_client.old_local_module.train is False
+    for param in fenda_client.old_local_module.parameters():
+        assert param.requires_grad is False
+
+    assert fenda_client.old_global_module.train is False
+    for param in fenda_client.old_global_module.parameters():
+        assert param.requires_grad is False
+
+    # Make sure the original model is still set to train
+    assert fenda_client.model.train is True
+    for param in fenda_client.model.parameters():
+        assert param.requires_grad is True
+
+
+@pytest.mark.parametrize("local_module,global_module,head_module", [(FeatureCnn(), FeatureCnn(), FendaHeadCnn())])
 def test_computing_contrastive_loss(get_fenda_client: FendaClient) -> None:  # noqa
     torch.manual_seed(42)
     fenda_client = get_fenda_client


### PR DESCRIPTION
# PR Type
[Fix]

This PR separates old_model and global model cloning from set_parameters and get_parameters functions in Moon and Fenda clients.

Clickup Ticket(s): [Link](https://app.clickup.com/t/86879vn75)


# Tests Added

Fenda_client and Moon_client test has updated accordingly.
