### PR TITLE
Skip flake8 on pre-commit bot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,5 +55,5 @@ ci:
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: weekly
-    skip: [mypy]
+    skip: [mypy,flake8]
     submodules: false


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

Flake8 is not able to run on pre-commit bot, so skipping it for now.

# Tests Added

NA
