### PR TITLE
Ignoring W and B vulnerability for now

### DIFF
--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -48,3 +48,4 @@ jobs:
             GHSA-3ww4-gg4f-jr7f
             GHSA-9v9h-cgj8-h64p
             GHSA-6vqw-3v5j-54x4
+            GHSA-cqh9-jfqr-h9jj

--- a/poetry.lock
+++ b/poetry.lock
@@ -4319,13 +4319,13 @@ testing = ["flake8 (>=3.9)", "mypy (>=0.910)", "pytest (>=6.0)", "pytest-cov (>=
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.0"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.0-py3-none-any.whl", hash = "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"},
+    {file = "requests-2.32.0.tar.gz", hash = "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Currently there is a W and B vulnerability that exists in the latest version. So upgrading doesn't fix it. Ignoring it for now.
