### PR TITLE
Fixing build failure on main due to new Tornado vulnerability

### DIFF
--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -49,3 +49,4 @@ jobs:
             GHSA-9v9h-cgj8-h64p
             GHSA-6vqw-3v5j-54x4
             GHSA-cqh9-jfqr-h9jj
+            GHSA-w235-7p84-xx57


### PR DESCRIPTION
# PR Type
Patch Fix

# Short Description

Fixing another Tornado vulnerability that must have been registered in pip-audit between the time of the last merged PRs tests and when it was merged in.

# Tests Added

None.
