### PR TITLE
Fix picai channel ordering

### DIFF
--- a/research/picai/preprocessing.py
+++ b/research/picai/preprocessing.py
@@ -120,12 +120,14 @@ class PicaiCase(Case):
         Class representing a case from the PICAI dataset.
 
         scan_paths filenames are assumed to have the following format: <patient_id>_<study_id>_<modality>.mha
-        where modality is a three letter string of ['t2w', 'adc', 'hbv']
+        where modality is a three letter string of ['t2w', 'adc', 'hbv']. Assumes the order of scan paths is
+        t2w, adc and hbv.
 
         annotation_path filename is assumed to have the following format: <patient_id>_<study_id>.nii.gz
 
         Args:
             scan_paths (Sequence[Path]): The set of paths where the scans associated with the Case are located.
+                Assumes the order of scan paths is t2w, adc, hbv.
             annotation_write_dir (Path): The path where the annotation associated with the Case is located.
             settings (PreprocessingSettings): The settings determining how the case is preprocessed.
         """
@@ -155,9 +157,8 @@ class PicaiCase(Case):
                 for the scans and the second entry is the file path to the corresponding annotation.
         """
         modality_suffix_map = {"t2w": "0000", "adc": "0001", "hbv": "0002"}
-        scan_paths = [path for path in sorted(self.scan_paths)]
         preprocessed_scan_paths = []
-        for path, scan in zip(scan_paths, self.scans):
+        for path, scan in zip(self.scan_paths, self.scans):
             scan_filename = Path(os.path.basename(path))
             scan_filename_without_extension = scan_filename.stem
             suffix = modality_suffix_map[scan_filename_without_extension[-3:]]

--- a/research/picai/preprocessing.py
+++ b/research/picai/preprocessing.py
@@ -120,14 +120,14 @@ class PicaiCase(Case):
         Class representing a case from the PICAI dataset.
 
         scan_paths filenames are assumed to have the following format: <patient_id>_<study_id>_<modality>.mha
-        where modality is a three letter string of ['t2w', 'adc', 'hbv']. Assumes the order of scan paths is
-        t2w, adc and hbv.
+        where modality is a three letter string of ['t2w', 'adc', 'hbv']. NOTE: the ordering self.scan_path
+        and self.scans must remain consistent.
 
         annotation_path filename is assumed to have the following format: <patient_id>_<study_id>.nii.gz
 
         Args:
             scan_paths (Sequence[Path]): The set of paths where the scans associated with the Case are located.
-                Assumes the order of scan paths is t2w, adc, hbv.
+                NOTE: self.scans will inherit the ordering of scan_paths and must remain consistently ordered.
             annotation_write_dir (Path): The path where the annotation associated with the Case is located.
             settings (PreprocessingSettings): The settings determining how the case is preprocessed.
         """
@@ -147,6 +147,7 @@ class PicaiCase(Case):
         and returns the scan file paths and annotation file path in a tuple.
 
         Assumes scan_paths and annotation_path filenames follow the format specified in class constructor.
+        NOTE: self.scans will inherit the ordering of scan_paths and must remain consistently ordered.
 
         Output scan_paths will be located at: scans_write_dir/<patient_id>_<stud_id>_<modality_id>.nii.gz
         where <modality_id> is a mapping from modality string to a 4 digit number specified by the mapping

--- a/tests/test_picai/test_case.py
+++ b/tests/test_picai/test_case.py
@@ -1,8 +1,10 @@
 import os
-from pathlib import Path
 import tempfile
+from pathlib import Path
+
 import numpy as np
 import SimpleITK as sitk
+
 from research.picai.preprocessing import PicaiCase, PreprocessingSettings
 
 
@@ -32,11 +34,7 @@ def test_read_and_write_picai_case() -> None:
         sitk.WriteImage(hbv_sitk, hbv_filename)
         sitk.WriteImage(annotation_sitk, annotation_filename)
 
-        scan_paths = [
-            t2w_filename,
-            adc_filename,
-            hbv_filename
-        ]
+        scan_paths = [t2w_filename, adc_filename, hbv_filename]
 
         original_np_scans = [t2w, adc, hbv]
 

--- a/tests/test_picai/test_case.py
+++ b/tests/test_picai/test_case.py
@@ -1,0 +1,65 @@
+import os
+from pathlib import Path
+import tempfile
+import numpy as np
+import SimpleITK as sitk
+from research.picai.preprocessing import PicaiCase, PreprocessingSettings
+
+
+def test_read_and_write_picai_case() -> None:
+    X, Y, Z = 32, 64, 128
+    with tempfile.TemporaryDirectory() as results_dir:
+        os.mkdir(f"{results_dir}/read")
+        os.mkdir(f"{results_dir}/write")
+
+        t2w = np.zeros((X, Y, Z), dtype=np.float32)
+        adc = np.ones((X, Y, Z), dtype=np.float32)
+        hbv = np.ones((X, Y, Z), dtype=np.float32) * 2.0
+        annotation = np.ones((X, Y, Z), dtype=np.float32) * 3.0
+
+        t2w_sitk = sitk.GetImageFromArray(t2w)
+        adc_sitk = sitk.GetImageFromArray(adc)
+        hbv_sitk = sitk.GetImageFromArray(hbv)
+        annotation_sitk = sitk.GetImageFromArray(annotation)
+
+        t2w_filename = Path(f"{results_dir}/read/file_t2w.mha")
+        adc_filename = Path(f"{results_dir}/read/file_adc.mha")
+        hbv_filename = Path(f"{results_dir}/read/file_hbv.mha")
+        annotation_filename = Path(f"{results_dir}/read/annotation.nii.gz")
+
+        sitk.WriteImage(t2w_sitk, t2w_filename)
+        sitk.WriteImage(adc_sitk, adc_filename)
+        sitk.WriteImage(hbv_sitk, hbv_filename)
+        sitk.WriteImage(annotation_sitk, annotation_filename)
+
+        scan_paths = [
+            t2w_filename,
+            adc_filename,
+            hbv_filename
+        ]
+
+        original_np_scans = [t2w, adc, hbv]
+
+        settings = PreprocessingSettings(Path(f"{results_dir}/write"), Path(f"{results_dir}/write"), None, None, None)
+
+        case = PicaiCase(scan_paths, annotation_filename, settings)
+        case.read()
+
+        read_np_scans = list(map(sitk.GetArrayFromImage, case.scans))
+        assert all((original == new).all() for original, new in zip(original_np_scans, read_np_scans))
+
+        assert (annotation == sitk.GetArrayFromImage(case.annotation)).all()
+
+        case.write()
+
+        write_t2w_filename = f"{results_dir}/write/file_0000.nii.gz"
+        write_adc_filename = f"{results_dir}/write/file_0001.nii.gz"
+        write_hbv_filename = f"{results_dir}/write/file_0002.nii.gz"
+        write_annotation_filename = f"{results_dir}/write/annotation.nii.gz"
+
+        write_scans = [sitk.ReadImage(f) for f in [write_t2w_filename, write_adc_filename, write_hbv_filename]]
+        write_np_scans = list(map(sitk.GetArrayFromImage, write_scans))
+
+        assert all((original == new).all() for original, new in zip(original_np_scans, write_np_scans))
+
+        assert (annotation == sitk.GetArrayFromImage(sitk.ReadImage(write_annotation_filename))).all()

--- a/tests/test_picai/test_case.py
+++ b/tests/test_picai/test_case.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -8,56 +7,55 @@ import SimpleITK as sitk
 from research.picai.preprocessing import PicaiCase, PreprocessingSettings
 
 
-def test_read_and_write_picai_case() -> None:
-    X, Y, Z = 32, 64, 128
-    with tempfile.TemporaryDirectory() as results_dir:
-        os.mkdir(f"{results_dir}/read")
-        os.mkdir(f"{results_dir}/write")
+def test_read_and_write_picai_case(tmp_path: Path) -> None:
+    X, Y, Z = 8, 16, 32
+    os.mkdir(f"{tmp_path}/read")
+    os.mkdir(f"{tmp_path}/write")
 
-        t2w = np.zeros((X, Y, Z), dtype=np.float32)
-        adc = np.ones((X, Y, Z), dtype=np.float32)
-        hbv = np.ones((X, Y, Z), dtype=np.float32) * 2.0
-        annotation = np.ones((X, Y, Z), dtype=np.float32) * 3.0
+    t2w = np.zeros((X, Y, Z), dtype=np.float32)
+    adc = np.ones((X, Y, Z), dtype=np.float32)
+    hbv = np.ones((X, Y, Z), dtype=np.float32) * 2.0
+    annotation = np.ones((X, Y, Z), dtype=np.float32) * 3.0
 
-        t2w_sitk = sitk.GetImageFromArray(t2w)
-        adc_sitk = sitk.GetImageFromArray(adc)
-        hbv_sitk = sitk.GetImageFromArray(hbv)
-        annotation_sitk = sitk.GetImageFromArray(annotation)
+    t2w_sitk = sitk.GetImageFromArray(t2w)
+    adc_sitk = sitk.GetImageFromArray(adc)
+    hbv_sitk = sitk.GetImageFromArray(hbv)
+    annotation_sitk = sitk.GetImageFromArray(annotation)
 
-        t2w_filename = Path(f"{results_dir}/read/file_t2w.mha")
-        adc_filename = Path(f"{results_dir}/read/file_adc.mha")
-        hbv_filename = Path(f"{results_dir}/read/file_hbv.mha")
-        annotation_filename = Path(f"{results_dir}/read/annotation.nii.gz")
+    t2w_filename = Path(f"{tmp_path}/read/file_t2w.mha")
+    adc_filename = Path(f"{tmp_path}/read/file_adc.mha")
+    hbv_filename = Path(f"{tmp_path}/read/file_hbv.mha")
+    annotation_filename = Path(f"{tmp_path}/read/annotation.nii.gz")
 
-        sitk.WriteImage(t2w_sitk, t2w_filename)
-        sitk.WriteImage(adc_sitk, adc_filename)
-        sitk.WriteImage(hbv_sitk, hbv_filename)
-        sitk.WriteImage(annotation_sitk, annotation_filename)
+    sitk.WriteImage(t2w_sitk, t2w_filename)
+    sitk.WriteImage(adc_sitk, adc_filename)
+    sitk.WriteImage(hbv_sitk, hbv_filename)
+    sitk.WriteImage(annotation_sitk, annotation_filename)
 
-        scan_paths = [t2w_filename, adc_filename, hbv_filename]
+    scan_paths = [t2w_filename, adc_filename, hbv_filename]
 
-        original_np_scans = [t2w, adc, hbv]
+    original_np_scans = [t2w, adc, hbv]
 
-        settings = PreprocessingSettings(Path(f"{results_dir}/write"), Path(f"{results_dir}/write"), None, None, None)
+    settings = PreprocessingSettings(Path(f"{tmp_path}/write"), Path(f"{tmp_path}/write"), None, None, None)
 
-        case = PicaiCase(scan_paths, annotation_filename, settings)
-        case.read()
+    case = PicaiCase(scan_paths, annotation_filename, settings)
+    case.read()
 
-        read_np_scans = list(map(sitk.GetArrayFromImage, case.scans))
-        assert all((original == new).all() for original, new in zip(original_np_scans, read_np_scans))
+    read_np_scans = list(map(sitk.GetArrayFromImage, case.scans))
+    assert all((original == new).all() for original, new in zip(original_np_scans, read_np_scans))
 
-        assert (annotation == sitk.GetArrayFromImage(case.annotation)).all()
+    assert (annotation == sitk.GetArrayFromImage(case.annotation)).all()
 
-        case.write()
+    case.write()
 
-        write_t2w_filename = f"{results_dir}/write/file_0000.nii.gz"
-        write_adc_filename = f"{results_dir}/write/file_0001.nii.gz"
-        write_hbv_filename = f"{results_dir}/write/file_0002.nii.gz"
-        write_annotation_filename = f"{results_dir}/write/annotation.nii.gz"
+    write_t2w_filename = f"{tmp_path}/write/file_0000.nii.gz"
+    write_adc_filename = f"{tmp_path}/write/file_0001.nii.gz"
+    write_hbv_filename = f"{tmp_path}/write/file_0002.nii.gz"
+    write_annotation_filename = f"{tmp_path}/write/annotation.nii.gz"
 
-        write_scans = [sitk.ReadImage(f) for f in [write_t2w_filename, write_adc_filename, write_hbv_filename]]
-        write_np_scans = list(map(sitk.GetArrayFromImage, write_scans))
+    write_scans = [sitk.ReadImage(f) for f in [write_t2w_filename, write_adc_filename, write_hbv_filename]]
+    write_np_scans = list(map(sitk.GetArrayFromImage, write_scans))
 
-        assert all((original == new).all() for original, new in zip(original_np_scans, write_np_scans))
+    assert all((original == new).all() for original, new in zip(original_np_scans, write_np_scans))
 
-        assert (annotation == sitk.GetArrayFromImage(sitk.ReadImage(write_annotation_filename))).all()
+    assert (annotation == sitk.GetArrayFromImage(sitk.ReadImage(write_annotation_filename))).all()


### PR DESCRIPTION
# PR Type
[Feature | **Fix** | Documentation | Other ]

# Short Description

Clickup Ticket(s): [Fix Picai Channel Ordering](https://app.clickup.com/t/8688u62qb)

The channel of the scans (t2w, adc, hbv) are being written with incorrect file names. The root of the cause was the write method of PicaiCase. The scan paths were being sorted when they should not. They are being passed with an assumed order. I also added to the documentation to make this more clear. 

# Tests Added

- Test to ensure we reading and writing picai case correctly
