### PR TITLE
Update MK-MMD Loss Suggestions and Tests

### DIFF
--- a/fl4health/losses/mkmmd_loss.py
+++ b/fl4health/losses/mkmmd_loss.py
@@ -1,6 +1,3 @@
-# multi-kernel maximum mean discrepancy
-# cao bin, HKUST, China, binjacobcao@gmail.com
-# free to charge for academic communication
 from logging import INFO
 from typing import Optional
 
@@ -18,7 +15,7 @@ class MkMmdLoss(torch.nn.Module):
         minimize_type_two_error: bool = True,
         normalize_features: bool = False,
         layer_name: Optional[str] = None,
-        construct_quadruples_per_kernel: bool = False,
+        perform_linear_approximation: bool = False,
     ) -> None:
         """
         Compute the multi-kernel maximum mean discrepancy (MK-MMD) between the source and target domains. Also allows
@@ -38,6 +35,9 @@ class MkMmdLoss(torch.nn.Module):
             normalize_features (Optional[bool], optional): Whether to normalize the features to have unit length before
                 computing the MK-MMD and optimizing betas. Defaults to False.
             layer_name (Optional[str], optional): The name of the layer to extract features from. Defaults to None.
+            perform_linear_approximation (Optional[bool], optional): Whether to use linear approximations for the
+                estimates of the mean and covariance of the kernel values. Experimentally, we have found that the
+                linear approximations largely hinder the statistical power of Mk-MMD. Defaults to False
         """
         super().__init__()
         self.device = device
@@ -61,7 +61,10 @@ class MkMmdLoss(torch.nn.Module):
         self.minimize_type_two_error = minimize_type_two_error
         self.normalize_features = normalize_features
         self.layer_name = layer_name
-        self.construct_quadruples_per_kernel = construct_quadruples_per_kernel
+        self.perform_linear_approximation = perform_linear_approximation
+
+    def normalize(self, X: torch.Tensor) -> torch.Tensor:
+        return torch.div(X, torch.linalg.norm(X, dim=1, keepdim=True))
 
     def construct_quadruples(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
         """
@@ -77,156 +80,218 @@ class MkMmdLoss(torch.nn.Module):
         v_i = torch.cat((X.reshape(n_samples // 2, 2, n_features), Y.reshape(n_samples // 2, 2, n_features)), dim=1)
         return v_i
 
-    def compute_euclidean_inner_products(self, v_i_quadruples: torch.Tensor) -> torch.Tensor:
-        # We want to compute the RBF kernel values. To do this, we need to compute ||x - y||^2 for the relevant pairs
-        # x and y. That is the inner product. Note that ||x - y||^2 = <x - y, x - y> = (x-y)^T(x-y)
-        # For the quadruples of the form (x,  x', y, y') we need distances for (x, x'), (y, y'), (x, y'), (x, y')
-        # NOTE: The inner product for a vector x^Tx is just the square and sum of the components of x
-        x_x_prime = (
-            torch.sum((v_i_quadruples[:, 0, :] ** 2), dim=1).reshape(-1, 1)
-            + torch.sum((v_i_quadruples[:, 1, :] ** 2), dim=1).reshape(1, -1)
-            - 2.0 * torch.mm(v_i_quadruples[:, 0, :], torch.transpose(v_i_quadruples[:, 1, :], 0, 1))
-        )
-        x_x_prime[x_x_prime < 0] = 0
-        y_y_prime = (
-            torch.sum((v_i_quadruples[:, 2, :] ** 2), dim=1).reshape(-1, 1)
-            + torch.sum((v_i_quadruples[:, 3, :] ** 2), dim=1).reshape(1, -1)
-            - 2.0 * torch.mm(v_i_quadruples[:, 2, :], torch.transpose(v_i_quadruples[:, 3, :], 0, 1))
-        )
-        y_y_prime[y_y_prime < 0] = 0
-        x_y_prime = (
-            torch.sum((v_i_quadruples[:, 0, :] ** 2), dim=1).reshape(-1, 1)
-            + torch.sum((v_i_quadruples[:, 3, :] ** 2), dim=1).reshape(1, -1)
-            - 2.0 * torch.mm(v_i_quadruples[:, 0, :], torch.transpose(v_i_quadruples[:, 3, :], 0, 1))
-        )
-        x_y_prime[x_y_prime < 0] = 0
-        x_prime_y = (
-            torch.sum((v_i_quadruples[:, 1, :] ** 2), dim=1).reshape(-1, 1)
-            + torch.sum((v_i_quadruples[:, 2, :] ** 2), dim=1).reshape(1, -1)
-            - 2.0 * torch.mm(v_i_quadruples[:, 1, :], torch.transpose(v_i_quadruples[:, 2, :], 0, 1))
-        )
-        x_prime_y[x_prime_y < 0] = 0
-        # each inner product is a tensor of dimension len(v_i_quadruples) x len(v_i_quadruples), we return a
-        #  tensor of shape 4 x len(v_i_quadruples) x len(v_i_quadruples)
-        return torch.cat(
-            [x_x_prime.unsqueeze(0), y_y_prime.unsqueeze(0), x_y_prime.unsqueeze(0), x_prime_y.unsqueeze(0)], dim=0
-        )
-
-    def compute_euclidean_inner_products_all(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
-        # We want to compute the RBF kernel values without using the quadruples. To do this, we need to compute
-        # ||x - y||^2 for x and y. That is the inner product. Note that ||x - y||^2 = <x - y, x - y> = (x-y)^T(x-y)
+    def compute_euclidean_inner_products(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+        # In this function, we assume that X, Y: n_samples, n_features
+        # We want to compute estimates of the expectation for each RBF kernel WITHOUT using a linear approximation.
+        # So we need to compute ||x - y||^2 for all pairs (x_j, x_k), (x_j, y_k), (x_k, y_j), and (y_j, y_k) for all
+        # j, k in range(n_samples).
+        # NOTE: ||x - y||^2 = <x - y, x - y> = <x, x> + <y, y> - 2<x, y>
         x_x_prime = (
             torch.sum((X**2), dim=1).reshape(-1, 1)
             + torch.sum((X**2), dim=1).reshape(1, -1)
             - 2.0 * torch.mm(X, torch.transpose(X, 0, 1))
         )
-        x_x_prime[x_x_prime < 0] = 0
         y_y_prime = (
             torch.sum((Y**2), dim=1).reshape(-1, 1)
             + torch.sum((Y**2), dim=1).reshape(1, -1)
             - 2.0 * torch.mm(Y, torch.transpose(Y, 0, 1))
         )
-        y_y_prime[y_y_prime < 0] = 0
         x_y_prime = (
             torch.sum((X**2), dim=1).reshape(-1, 1)
             + torch.sum((Y**2), dim=1).reshape(1, -1)
             - 2.0 * torch.mm(X, torch.transpose(Y, 0, 1))
         )
-        x_y_prime[x_y_prime < 0] = 0
         x_prime_y = (
             torch.sum((Y**2), dim=1).reshape(-1, 1)
             + torch.sum((X**2), dim=1).reshape(1, -1)
             - 2.0 * torch.mm(Y, torch.transpose(X, 0, 1))
         )
+
+        # Correct any values that ended up nearly but not identically zero (||x-y||^2 should be semi-definite)
+        x_x_prime[x_x_prime < 0] = 0
+        y_y_prime[y_y_prime < 0] = 0
+        x_y_prime[x_y_prime < 0] = 0
         x_prime_y[x_prime_y < 0] = 0
-        # each inner product is a tensor of dimension len(v_i_quadruples) x len(v_i_quadruples), we return a
+
+        # each inner product is a tensor of dimension n_samples x n_samples, we return a
         # tensor of shape 4 x len(X) x len(Y)
         return torch.cat(
-            [x_x_prime.unsqueeze(0), y_y_prime.unsqueeze(0), x_y_prime.unsqueeze(0), x_prime_y.unsqueeze(0)], dim=0
+            [x_x_prime.unsqueeze(0), y_y_prime.unsqueeze(0), x_y_prime.unsqueeze(0), x_prime_y.unsqueeze(0)]
         )
+
+    def compute_euclidean_inner_products_linear(self, v_i_quadruples: torch.Tensor) -> torch.Tensor:
+        # Shape of v_i_quadruples is n_samples/2 x 4 x n_features
+        # v_i = [x_{2i-1}, x_{2i}, y_{2i-1}, y_{2i}]
+        #
+        # We want to compute the RBF kernel values. To do this, we need to compute ||x - y||^2 for the relevant pairs
+        # x and y. That is the inner product. Note that ||x - y||^2 = <x - y, x - y> = (x-y)^T(x-y)
+        # For the quadruples of the form (x,  x', y, y') we need distances for pairings (x, x'), (y, y'), (x, y'),
+        # (x, y')
+        x_x_prime = torch.sum((v_i_quadruples[:, 0, :] - v_i_quadruples[:, 1, :]) ** 2, dim=1, keepdim=True)
+        y_y_prime = torch.sum((v_i_quadruples[:, 2, :] - v_i_quadruples[:, 3, :]) ** 2, dim=1, keepdim=True)
+        x_y_prime = torch.sum((v_i_quadruples[:, 0, :] - v_i_quadruples[:, 3, :]) ** 2, dim=1, keepdim=True)
+        x_prime_y = torch.sum((v_i_quadruples[:, 1, :] - v_i_quadruples[:, 2, :]) ** 2, dim=1, keepdim=True)
+
+        # each inner product is a tensor of dimension len(v_i_quadruples), we return a tensor of shape
+        # len(v_i_quadruples) x 4
+        return torch.cat([x_x_prime, y_y_prime, x_y_prime, x_prime_y], dim=1)
 
     def compute_h_u_from_inner_products(self, inner_products: torch.Tensor, gamma: torch.Tensor) -> torch.Tensor:
         # Gamma should be of shape torch.Tensor([gamma])
         assert gamma.shape == (1,)
-        # inner_products has shape number of 4 x v_i_quadruples x v_i_quadruples or 4 x len(X) x len(Y)
-        # h_u_componets should have the same shape
+        # inner_products has shape of 4 x n_samples x n_samples
+        # h_u_components should have the same shape
         h_u_components = torch.exp((-1 * inner_products) / gamma)
-        # Each column of h_u_components should now be u(x_{2i-1}, x_{2i}), u(y_{2i-1}, y_{2i}), u(x_{2i-1}, y_{2i}),
-        # and u(x_{2i}, y_{2i-1}), where u is the kernel_index^th kernel
+        # Each first dimension of h_u_components should now be u(x_j, x_k), u(y_j, y_k), u(x_j, y_k), and u(y_j, x_k),
+        # where u is the kernel_index^th kernel and j, k index over samples
         # So we compute:
-        #   h_u[x_{2i-1}, x_{2i},y_{2i-1}, y_{2i}] =  u(x_{2i-1}, x_{2i}) + u(y_{2i-1}, y_{2i})
-        # - u(x_{2i-1}, y_{2i}) - u(x_{2i}, y_{2i-1})
+        #   h_u[x_j, x_k,y_j, y_k] =  u(x_j, x_k) + u(y_j, y_k) - u(x_j, y_k) - u(y_j, x_k)
         h_u = h_u_components[0, :] + h_u_components[1, :] - h_u_components[2, :] - h_u_components[3, :]
-        # this results in a matrix of shape 1 xlen(v_i_quadruples) x len(v_i_quadruples) or 1 x len(X) x len(Y)
+        # this results in a matrix of shape 1 x n_samples x n_samples
         return h_u.unsqueeze(0)
 
-    def compute_all_h_u_from_inner_products(self, inner_product_quadruples: torch.Tensor) -> torch.Tensor:
+    def compute_h_u_from_inner_products_linear(
+        self, inner_products: torch.Tensor, gamma: torch.Tensor
+    ) -> torch.Tensor:
+        # Gamma should be of shape torch.Tensor([gamma])
+        assert gamma.shape == (1,)
+        # inner_products has shape number of len(v_i_quadruples) x 4 since this is the linear approximation strategy
+        # h_u_components should have the same shape
+        h_u_components = torch.exp((-1 * inner_products) / gamma)
+        # Each column of h_u_components should now be u(x_{2i-1}, x_{2i}), u(y_{2i-1}, y_{2i}), u(x_{2i-1}, y_{2i}),
+        # and u(x_{2i}, y_{2i-1}), where u is the kernel_index^th kernel and i indexes over quadruples
+        # So we compute:
+        #   h_u[x_{2i-1}, x_{2i},y_{2i-1}, y_{2i}] =  u(x_{2i-1}, x_{2i}) + u(y_{2i-1}, y_{2i})
+        #       - u(x_{2i-1}, y_{2i}) - u(x_{2i}, y_{2i-1})
+        h_u = h_u_components[:, 0] + h_u_components[:, 1] - h_u_components[:, 2] - h_u_components[:, 3]
+        # this results in a matrix of shape 1 x number of v_i_quadruples
+        return h_u.unsqueeze(0)
+
+    def compute_all_h_u_from_inner_products(self, inner_product_all_samples: torch.Tensor) -> torch.Tensor:
         k_list = [
-            self.compute_h_u_from_inner_products(inner_product_quadruples, gamma.reshape(1)) for gamma in (self.gammas)
+            self.compute_h_u_from_inner_products(inner_product_all_samples, gamma.reshape(1)) for gamma in self.gammas
         ]
-        # Matrix should be of shape number of kernels x number of quadruples, since we compute the kernel value on all
-        # quadrules for every kernel
+        # Matrix should be of shape number of kernels x n_samples x n_samples, since we compute the kernel value on all
+        # possible combinations of pairs (x_j, y_j) (x_k, y_k) for every kernel.
         return torch.cat(k_list)
 
-    def compute_all_h_u_per_v_i(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+    def compute_all_h_u_from_inner_products_linear(self, inner_product_quadruples: torch.Tensor) -> torch.Tensor:
+        # For the linear approximation version the shape of inner_product_quadruples is len(v_i_quadruples) x 4
+        k_list = [
+            self.compute_h_u_from_inner_products_linear(inner_product_quadruples, gamma.reshape(1))
+            for gamma in self.gammas
+        ]
+        # Matrix should be of shape number of kernels x number of quadruples, since we compute the kernel value on all
+        # quadruples for every kernel
+        return torch.cat(k_list)
+
+    def compute_all_h_u_linear(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+        # In this function, we assume that X, Y: n_samples, n_features
         # v_i = [x_{2i-1}, x_{2i}, y_{2i-1}, y_{2i}]
         v_is = self.construct_quadruples(X, Y)
-        # For the quadruples of the form (x,  x', y, y') we need distances for (x, x'), (y, y'), (x, y'), (x, y')
-        inner_product_quadruples = self.compute_euclidean_inner_products(v_is)
+        # For the quadruples of the form (x,  x', y, y') we need distances for pairs (x, x'), (y, y'), (x, y'), (x, y')
+        inner_product_quadruples = self.compute_euclidean_inner_products_linear(v_is)
         # all_h_u has shape number of kernels x number of quadruples
-        all_h_u = self.compute_all_h_u_from_inner_products(inner_product_quadruples)
+        all_h_u = self.compute_all_h_u_from_inner_products_linear(inner_product_quadruples)
         return all_h_u
 
-    def compute_all_h_u_per_v_i_all(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+    def compute_all_h_u_all_samples(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+        # In this function, we assume that X, Y: n_samples, n_features
         # We don't need to construct the quadruples here, we can just compute the inner products directly
-        inner_product = self.compute_euclidean_inner_products_all(X, Y)
-        # all_h_u has shape number of kernels x number of quadruples
+        inner_product = self.compute_euclidean_inner_products(X, Y)
+        # all_h_u has shape number of kernels x n_samples x n_samples
         all_h_u = self.compute_all_h_u_from_inner_products(inner_product)
         return all_h_u
 
-    def compute_hat_d_per_kernel(self, all_h_u_per_v_i: torch.Tensor) -> torch.Tensor:
-        # all_h_u_per_vi has shape number kernels x number of v_is. Each row is h_u(v_i) for kernel u with the ith
-        # column being that kernel evaluated on v_i.
-        # output shape is number of kernels x 1
-        return torch.mean(all_h_u_per_v_i, dim=(1, 2)).unsqueeze(1)
+    def compute_hat_d_per_kernel(self, all_h_u_per_sample: torch.Tensor) -> torch.Tensor:
+        # all_h_u_per_sample has two possible shapes.
+        # If we're using a linear approximation for the stats it has shape (n kernels, number of quadruples)
+        # If we're using a full approximation for the stats it has shape (n kernels, n_samples, n_samples)
+        # The data corresponding to the first dimension is values for a single kernel. For either shape
+        # we want the mean value of all entries per kernel
+        dim_to_reduce = tuple(range(1, all_h_u_per_sample.dim()))
+        # Taking the mean across kernel entries, output shape is number of kernels x 1
+        return torch.mean(all_h_u_per_sample, dim=dim_to_reduce).unsqueeze(1)
 
     def compute_mkmmd(self, X: torch.Tensor, Y: torch.Tensor, beta: torch.Tensor) -> torch.Tensor:
         # Normalize the features if necessary to have unit length
         if self.normalize_features:
             X = self.normalize(X)
             Y = self.normalize(Y)
+
         # In this function, we assume that X, Y: n_samples, n_features are the same size and that beta is a tensor of
         # shape number of kernels x 1
-        if self.construct_quadruples_per_kernel:
-            all_h_u_per_vi = self.compute_all_h_u_per_v_i(X, Y)
+        if self.perform_linear_approximation:
+            all_h_u_per_vi = self.compute_all_h_u_linear(X, Y)
+            hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_vi)
         else:
-            all_h_u_per_vi = self.compute_all_h_u_per_v_i_all(X, Y)
-        hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_vi)
-        # Take the dot product between the indivudal kernel hat_d values to scale by the basis coefficients
+            all_h_u_per_sample = self.compute_all_h_u_all_samples(X, Y)
+            hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_sample)
+        # Take the dot product between the individual kernel hat_d values to scale by the basis coefficients
         return torch.mm(beta.t(), hat_d_per_kernel)[0][0]
 
-    def create_h_u_delta_w_i(self, all_h_u_per_v_i: torch.Tensor) -> torch.Tensor:
-        # Implementing the new version of the h_u_delta_w_i calculation based on David's Notes
-        all_E_h_u_per_v_i = torch.mean(all_h_u_per_v_i, dim=(1, 2), keepdim=True)
-        # pairing the h_u(v_i) values as h_u(v_{2i-1}), h_u(v_{2i}), think w_is from the paper
-        return all_h_u_per_v_i - all_E_h_u_per_v_i
-
-    def compute_hat_Q_k(self, all_h_u_per_v_i: torch.Tensor) -> torch.Tensor:
+    def form_h_u_delta_w_i(self, all_h_u_per_v_i: torch.Tensor) -> torch.Tensor:
         # all_h_u_per_v_i has dimension number kernels x number of v_i quadruples
-        h_u_delta_w_i = self.create_h_u_delta_w_i(all_h_u_per_v_i)
+        n_kernels, n_v_i_s = all_h_u_per_v_i.shape
+        # if the number of v_is is not divisible by two just drop the final ones
+        if n_v_i_s % 2 == 1:
+            all_h_u_per_v_i = all_h_u_per_v_i[:, :-1]
+        # pairing the h_u(v_i) values as h_u(v_{2i-1}), h_u(v_{2i}), think w_is from the paper
+        h_u_v_i_pairs = all_h_u_per_v_i.reshape(n_kernels, n_v_i_s // 2, 2)
+        return h_u_v_i_pairs[:, :, 0] - h_u_v_i_pairs[:, :, 1]
+
+    def compute_hat_Q_k_linear(self, all_h_u_per_v_i: torch.Tensor) -> torch.Tensor:
+        # all_h_u_per_v_i has dimension number kernels x number of v_i quadruples
+        h_u_delta_w_i = self.form_h_u_delta_w_i(all_h_u_per_v_i)
 
         Q_k_matrix: torch.Tensor = torch.zeros((self.kernel_num, self.kernel_num)).to(self.device)
         len_w_is = h_u_delta_w_i.shape[1]
-        # For each basis function we're adding in the value of h_{j, \Delta}(w_i)*h_{k, \Delta}(w_i) from the
-        # construction above to the proper entry in Q. Note that Q is symmetric. So we can construct the symmetric
-        # entries at the same time.
-        for j in range(self.kernel_num):
-            for k in range(j + 1):
-                Q_k_matrix[j][k] += torch.sum(h_u_delta_w_i[j] * h_u_delta_w_i[k])
-                if j != k:
-                    Q_k_matrix[k][j] += torch.sum(h_u_delta_w_i[j] * h_u_delta_w_i[k])
+        for i in range(len_w_is):
+            # For each basis function we're adding in the value of h_{j, \Delta}(w_i)*h_{k, \Delta}(w_i) from the
+            # construction above to the proper entry in Q. Note that Q is symmetric. So we can construct the symmetric
+            # entries at the same time.
+            for j in range(self.kernel_num):
+                for k in range(j + 1):
+                    Q_k_matrix[j][k] += h_u_delta_w_i[j][i] * h_u_delta_w_i[k][i]
+                    if j != k:
+                        Q_k_matrix[k][j] += h_u_delta_w_i[j][i] * h_u_delta_w_i[k][i]
         # Q_k_matrix has shape number of kernels x number of kernels
-        return Q_k_matrix / ((len_w_is) ** 2 - 1)
+        return Q_k_matrix / len_w_is
+
+    def form_kernel_samples_minus_expectation(
+        self, all_h_u_per_sample: torch.Tensor, hat_d_per_kernel: torch.Tensor
+    ) -> torch.Tensor:
+        # all_h_u_per_sample has shape num kernels x n_samples x n_samples, for each index in the first dimension,
+        # the n_samples x n_samples represent the values of the kernel evaluated on samples (x_j, y_j) x (x_k, y_k)
+        # hat_d_per_kernel has shape num kernels x 1. This is the expectation of each kernel over all those samples
+        _, rows, columns = all_h_u_per_sample.shape
+        # We want to subtract the expectation for the kernel from all sample values for the kernel in
+        # all_h_u_per_sample, so we repeat the expectations to produce the right shape.
+        repeated_hat_d_per_kernel = hat_d_per_kernel.unsqueeze(1).repeat(1, rows, columns)
+        return all_h_u_per_sample - repeated_hat_d_per_kernel
+
+    def compute_hat_Q_k(self, all_h_u_per_sample: torch.Tensor, hat_d_per_kernel: torch.Tensor) -> torch.Tensor:
+        # all_h_u_per_sample has dimension num kernels x n_samples x n_samples
+        n_samples = all_h_u_per_sample.shape[1]
+        kernel_samples_minus_kernel_expectation = self.form_kernel_samples_minus_expectation(
+            all_h_u_per_sample, hat_d_per_kernel
+        )
+        Q_k_matrix: torch.Tensor = torch.zeros((self.kernel_num, self.kernel_num)).to(self.device)
+        # For each basis function we need to compute the covariance between the kernels where
+        # Cov(X, Y) = E[(X - E[X])(Y - E[Y])], and X and Y are random variables representing the kernel values over
+        # distributions P, Q. For kernels h_{k_i} and h_{k_j} this can be estimated as
+        # \frac{1}{n^2 -1} \sum_{s, t} (h_{k_i}(x_s, x_t, y_s, y_t) - \hat{d}_{k_i}(p, q))
+        #     \cdot (h_{k_j}(x_s, x_t, y_s, y_t) - \hat{d}_{k_j}(p, q))
+        # So we loop over the different kernel combinations
+        for i in range(self.kernel_num):
+            for j in range(self.kernel_num):
+                product_of_variances = (
+                    kernel_samples_minus_kernel_expectation[i, :, :] * kernel_samples_minus_kernel_expectation[j, :, :]
+                )
+                # Compute the expectation to get Cov(h_{k_i}, h_{k_j}).
+                # NOTE: the n^2-1 correction is because we're using expectation estimates
+                Q_k_matrix[i][j] = (1.0 / (n_samples**2 - 1.0)) * torch.sum(product_of_variances)
+        return Q_k_matrix
 
     def beta_with_extreme_kernel_base_values(
         self, hat_d_per_kernel: torch.Tensor, hat_Q_k: torch.Tensor, minimize_type_two_error: bool = True
@@ -310,30 +375,33 @@ class MkMmdLoss(torch.nn.Module):
             regularized_Q_k, p, G, h, hat_d_per_kernel.t(), b
         ).t()
 
-    def normalize(self, X: torch.Tensor) -> torch.Tensor:
-        return torch.div(X, torch.linalg.norm(X, dim=1).unsqueeze(dim=1))
-
     def optimize_betas(self, X: torch.Tensor, Y: torch.Tensor, lambda_m: float = 1e-5) -> torch.Tensor:
+        # In this function, we assume that X, Y: n_samples, n_features
+
         # Normalize the features if necessary to have unit length
         if self.normalize_features:
             X = self.normalize(X)
             Y = self.normalize(Y)
-        # In this function, we assume that X, Y: n_samples, n_features
-        if self.construct_quadruples_per_kernel:
-            all_h_u_per_v_i = self.compute_all_h_u_per_v_i(X, Y)
-        else:
-            all_h_u_per_v_i = self.compute_all_h_u_per_v_i_all(X, Y)
 
-        # shape of hat_d_per_kernel is number of kernels x 1
-        hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_v_i)
-        # check to see that at least one of them is positive. If none of them are positive, then select a single kernel
-        # with largest hat_d, similar to the suggestion of Gretton et al. in "Optimal Kernel Choice for Large-Scale
-        # Two-Sample Tests", 2012
-        # shape of hat_Q_k is number of kernels x number of kernels
-        hat_Q_k = self.compute_hat_Q_k(all_h_u_per_v_i)
+        if self.perform_linear_approximation:
+            all_h_u_per_v_i = self.compute_all_h_u_linear(X, Y)
+            # shape of hat_d_per_kernel is number of kernels x 1
+            hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_v_i)
+            # shape of hat_Q_k is number of kernels x number of kernels
+            hat_Q_k = self.compute_hat_Q_k_linear(all_h_u_per_v_i)
+        else:
+            all_h_u_per_sample = self.compute_all_h_u_all_samples(X, Y)
+            # shape of hat_d_per_kernel is number of kernels x 1
+            hat_d_per_kernel = self.compute_hat_d_per_kernel(all_h_u_per_sample)
+            # shape of hat_Q_k is number of kernels x number of kernels
+            hat_Q_k = self.compute_hat_Q_k(all_h_u_per_sample, hat_d_per_kernel)
+
         # Eigen shift hat_Q_k and scale by 2 as the QP setup scales by 1/2
         regularized_Q_k = 2 * hat_Q_k + lambda_m * torch.eye(self.kernel_num).to(self.device)
 
+        # check to see that at least one of hat_d_per_kernel is positive. If none of them are positive, then select a
+        # single kernel with largest hat_d, similar to the suggestion of Gretton et al. in "Optimal Kernel Choice for
+        # Large-Scale Two-Sample Tests", 2012
         if not torch.any(hat_d_per_kernel > 0):
             log(INFO, f"None of the estimates for hat_d are positive: {hat_d_per_kernel.squeeze()}.")
             return self.beta_with_extreme_kernel_base_values(
@@ -342,22 +410,22 @@ class MkMmdLoss(torch.nn.Module):
 
         if self.minimize_type_two_error:
             try:
-                unnormalized_betas = self.form_and_solve_qp(hat_d_per_kernel, regularized_Q_k)
+                raw_betas = self.form_and_solve_qp(hat_d_per_kernel, regularized_Q_k)
             except Exception as e:
                 # If we can't solve the QP due to infeasibility, then we keep the previous betas
                 if self.layer_name is not None:
                     log(INFO, f"{e} We keep previous betas for layer {self.layer_name}.")
                 else:
                     log(INFO, f"{e} We keep previous betas.")
-                unnormalized_betas = self.betas
+                raw_betas = self.betas
         else:
             # If we're trying to maximize the type II error, then we are trying to maximize a convex function over a
             # convex polygon of beta values. So the maximum is found at one of the vertices
-            unnormalized_betas = self.get_best_vertex_for_objective_function(hat_d_per_kernel, regularized_Q_k)
+            raw_betas = self.get_best_vertex_for_objective_function(hat_d_per_kernel, regularized_Q_k)
 
         # We want to ensure that the betas are non-negative
-        unnormalized_betas = torch.clamp(unnormalized_betas, min=0)
-        optimized_betas = (1.0 / torch.sum(unnormalized_betas)) * unnormalized_betas
+        raw_betas = torch.clamp(raw_betas, min=0)
+        optimized_betas = (1.0 / torch.sum(raw_betas)) * raw_betas
         return optimized_betas
 
     def forward(self, Xs: torch.Tensor, Xt: torch.Tensor) -> torch.Tensor:

--- a/fl4health/losses/mkmmd_loss.py
+++ b/fl4health/losses/mkmmd_loss.py
@@ -246,15 +246,14 @@ class MkMmdLoss(torch.nn.Module):
 
         Q_k_matrix: torch.Tensor = torch.zeros((self.kernel_num, self.kernel_num)).to(self.device)
         len_w_is = h_u_delta_w_i.shape[1]
-        for i in range(len_w_is):
-            # For each basis function we're adding in the value of h_{j, \Delta}(w_i)*h_{k, \Delta}(w_i) from the
-            # construction above to the proper entry in Q. Note that Q is symmetric. So we can construct the symmetric
-            # entries at the same time.
-            for j in range(self.kernel_num):
-                for k in range(j + 1):
-                    Q_k_matrix[j][k] += h_u_delta_w_i[j][i] * h_u_delta_w_i[k][i]
-                    if j != k:
-                        Q_k_matrix[k][j] += h_u_delta_w_i[j][i] * h_u_delta_w_i[k][i]
+        # For each basis function we're adding in the value of h_{j, \Delta}(w_i)*h_{k, \Delta}(w_i) from the
+        # construction above to the proper entry in Q. Note that Q is symmetric. So we can construct the symmetric
+        # entries at the same time.
+        for j in range(self.kernel_num):
+            for k in range(j + 1):
+                Q_k_matrix[j][k] += torch.sum(h_u_delta_w_i[j] * h_u_delta_w_i[k])
+                if j != k:
+                    Q_k_matrix[k][j] += torch.sum(h_u_delta_w_i[j] * h_u_delta_w_i[k])
         # Q_k_matrix has shape number of kernels x number of kernels
         return Q_k_matrix / len_w_is
 

--- a/fl4health/losses/mkmmd_loss.py
+++ b/fl4health/losses/mkmmd_loss.py
@@ -321,7 +321,7 @@ class MkMmdLoss(torch.nn.Module):
     def get_best_vertex_for_objective_function(
         self, hat_d_per_kernel: torch.Tensor, hat_Q_k: torch.Tensor
     ) -> torch.Tensor:
-        # vertices have shape num kernels x 1
+        # vertices_weights have shape num kernels x 1
         vertices_weights = self.compute_vertices(hat_d_per_kernel)
         maximum_value = -torch.inf
         best_index = 0

--- a/tests/losses/test_mkmmd_loss.py
+++ b/tests/losses/test_mkmmd_loss.py
@@ -37,14 +37,30 @@ Y = torch.Tensor(
 
 DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
+mkmmd_loss_linear = MkMmdLoss(DEVICE, gammas=torch.Tensor([2, 1, 1 / 2]), perform_linear_approximation=True)
+mkmmd_loss_linear.betas = torch.Tensor([1.5, 2.0, -1.0]).reshape(-1, 1).to(DEVICE)
+quads = mkmmd_loss_linear.construct_quadruples(X, Y)
+inner_products_linear = mkmmd_loss_linear.compute_euclidean_inner_products_linear(quads)
+all_h_us_linear = mkmmd_loss_linear.compute_all_h_u_from_inner_products_linear(inner_products_linear)
+hat_d_per_kernel_linear = mkmmd_loss_linear.compute_hat_d_per_kernel(all_h_us_linear)
+h_u_delta_w_i = mkmmd_loss_linear.form_h_u_delta_w_i(all_h_us_linear)
+Q_k_linear = mkmmd_loss_linear.compute_hat_Q_k_linear(all_h_us_linear)
+
 mkmmd_loss = MkMmdLoss(DEVICE, gammas=torch.Tensor([2, 1, 1 / 2]))
 mkmmd_loss.betas = torch.Tensor([1.5, 2.0, -1.0]).reshape(-1, 1).to(DEVICE)
-quads = mkmmd_loss.construct_quadruples(X, Y)
-inner_products = mkmmd_loss.compute_euclidean_inner_products(quads)
-all_h_us = mkmmd_loss.compute_all_h_u_from_inner_products(inner_products)
-hat_d_per_kernel = mkmmd_loss.compute_hat_d_per_kernel(all_h_us)
-h_u_delta_w_i = mkmmd_loss.create_h_u_delta_w_i(all_h_us)
-Q_k = mkmmd_loss.compute_hat_Q_k(all_h_us)
+inner_products_all = mkmmd_loss.compute_euclidean_inner_products(X, Y)
+all_h_us_all = mkmmd_loss.compute_all_h_u_from_inner_products(inner_products_all)
+hat_d_per_kernel_all = mkmmd_loss.compute_hat_d_per_kernel(all_h_us_all)
+kernel_samples_minus_expectation = mkmmd_loss.form_kernel_samples_minus_expectation(all_h_us_all, hat_d_per_kernel_all)
+Q_k = mkmmd_loss.compute_hat_Q_k(all_h_us_all, hat_d_per_kernel_all)
+
+
+def test_normalize_features() -> None:
+    normalized_X = mkmmd_loss.normalize(X)
+    assert normalized_X.shape == (11, 3)
+    norm_of_rows = torch.linalg.norm(normalized_X, dim=1)
+    for index in range(11):
+        assert pytest.approx(norm_of_rows[index].item(), abs=0.0001) == 1.0
 
 
 def test_construct_quadruples() -> None:
@@ -63,43 +79,81 @@ def test_construct_quadruples() -> None:
     assert torch.all(quads.eq(quads_target))
 
 
-def test_inner_products_calculation() -> None:
+def test_inner_products_calculation_linear() -> None:
     # inner products should be of shape n_samples // 2 x 4 (inner product component)
-    assert inner_products.shape == (5, 4)
-    inner_product_quad_1_0 = (2 * 2 + 1 * 1 + (-3) * (-3)) / 3
-    inner_product_quad_1_1 = (2 * 2 + 0 * 0 + (-1) * (-1)) / 3
-    inner_product_quad_1_2 = (3 * 3 + (-2) * (-2) + (-1) * (-1)) / 3
-    inner_product_quad_1_3 = ((-1) * (-1) + (-3) * (-3) + (3) * (3)) / 3
-    assert inner_products[1][0] == inner_product_quad_1_0
-    assert inner_products[1][1] == inner_product_quad_1_1
-    assert inner_products[1][2] == inner_product_quad_1_2
-    assert inner_products[1][3] == inner_product_quad_1_3
+    assert inner_products_linear.shape == (5, 4)
+    inner_product_quad_1_0 = 2 * 2 + 1 * 1 + (-3) * (-3)
+    inner_product_quad_1_1 = 2 * 2 + 0 * 0 + (-1) * (-1)
+    inner_product_quad_1_2 = 3 * 3 + (-2) * (-2) + (-1) * (-1)
+    inner_product_quad_1_3 = (-1) * (-1) + (-3) * (-3) + (3) * (3)
+    assert inner_products_linear[1][0] == inner_product_quad_1_0
+    assert inner_products_linear[1][1] == inner_product_quad_1_1
+    assert inner_products_linear[1][2] == inner_product_quad_1_2
+    assert inner_products_linear[1][3] == inner_product_quad_1_3
 
-    inner_product_quad_4_0 = (0 * 0 + 2 * 2 + 3 * 3) / 3
-    inner_product_quad_4_1 = ((-1) * (-1) + (1) * (1) + (-3) * (-3)) / 3
-    inner_product_quad_4_2 = (0 * 0 + 3 * 3 + 0 * 0) / 3
-    inner_product_quad_4_3 = (1 * 1 + 0 * 0 + 0 * 0) / 3
-    assert inner_products[4][0] == inner_product_quad_4_0
-    assert inner_products[4][1] == inner_product_quad_4_1
-    assert inner_products[4][2] == inner_product_quad_4_2
-    assert inner_products[4][3] == inner_product_quad_4_3
+    inner_product_quad_4_0 = 0 * 0 + 2 * 2 + 3 * 3
+    inner_product_quad_4_1 = (-1) * (-1) + (1) * (1) + (-3) * (-3)
+    inner_product_quad_4_2 = 0 * 0 + 3 * 3 + 0 * 0
+    inner_product_quad_4_3 = 1 * 1 + 0 * 0 + 0 * 0
+    assert inner_products_linear[4][0] == inner_product_quad_4_0
+    assert inner_products_linear[4][1] == inner_product_quad_4_1
+    assert inner_products_linear[4][2] == inner_product_quad_4_2
+    assert inner_products_linear[4][3] == inner_product_quad_4_3
 
 
-def test_compute_h_u_from_inner_products() -> None:
+def test_inner_product_calculations_all() -> None:
+    assert inner_products_all.shape == (4, 11, 11)
+
+    inner_product_x3_x3 = 0.0
+    inner_product_x1_x2 = (3.0 - 4.0) * (3.0 - 4.0) + (4.0 - 2.0) * (4.0 - 2.0) + (4.0 - 1.0) * (4.0 - 1.0)
+    # Index into XX'
+    pytest.approx(inner_products_all[0, 3, 3], abs=0.0001) == inner_product_x3_x3
+    pytest.approx(inner_products_all[0, 1, 2], abs=0.0001) == inner_product_x1_x2
+    # Should be symmetric
+    pytest.approx(inner_products_all[0, 2, 1], abs=0.0001) == inner_product_x1_x2
+
+    inner_product_x1_y1 = (3.0 - 1.0) * (3.0 - 1.0) + (4.0 - 2.0) * (4.0 - 2.0) + (4.0 - 2.0) * (4.0 - 2.0)
+    inner_product_x1_y3 = (3.0 - 1.0) * (3.0 - 1.0) + (4.0 - 4.0) * (4.0 - 4.0) + (4.0 - 2.0) * (4.0 - 2.0)
+    # Index into XY'
+    pytest.approx(inner_products_all[2, 1, 1], abs=0.0001) == inner_product_x1_y1
+    pytest.approx(inner_products_all[2, 1, 3], abs=0.0001) == inner_product_x1_y3
+    # Should be transpose in X'Y
+    pytest.approx(inner_products_all[3, 1, 1], abs=0.0001) == inner_product_x1_y1
+    pytest.approx(inner_products_all[3, 3, 1], abs=0.0001) == inner_product_x1_y3
+
+    inner_product_y2_y2 = 0.0
+    inner_product_y5_y8 = (4.0 - 3.0) * (4.0 - 3.0) + (1.0 - 2.0) * (1.0 - 2.0) + (2.0 - 1.0) * (2.0 - 1.0)
+    # Index into YY'
+    pytest.approx(inner_products_all[1, 2, 2], abs=0.0001) == inner_product_y2_y2
+    pytest.approx(inner_products_all[1, 5, 8], abs=0.0001) == inner_product_y5_y8
+    # Should be symmetric
+    pytest.approx(inner_products_all[1, 8, 5], abs=0.0001) == inner_product_y5_y8
+
+    inner_product_y1_x1 = (1.0 - 3.0) * (1.0 - 3.0) + (2.0 - 4.0) * (2.0 - 4.0) + (2.0 - 4.0) * (2.0 - 4.0)
+    inner_product_y3_x3 = (1.0 - 2.0) * (1.0 - 2.0) + (4.0 - 1.0) * (4.0 - 1.0) + (2.0 - 4.0) * (2.0 - 4.0)
+    # Index into X'Y
+    pytest.approx(inner_products_all[3, 1, 1], abs=0.0001) == inner_product_y1_x1
+    pytest.approx(inner_products_all[3, 3, 3], abs=0.0001) == inner_product_y3_x3
+    # Should be transpose in X'Y, but we're looking at the diagonal
+    pytest.approx(inner_products_all[2, 1, 1], abs=0.0001) == inner_product_y1_x1
+    pytest.approx(inner_products_all[2, 3, 1], abs=0.0001) == inner_product_y3_x3
+
+
+def test_compute_h_u_from_inner_products_linear() -> None:
     gamma_1, gamma_2 = torch.Tensor([2]).to(DEVICE), torch.Tensor([1]).to(DEVICE)
-    h_u_gamma_1 = mkmmd_loss.compute_h_u_from_inner_products(inner_products, gamma_1)
-    h_u_gamma_2 = mkmmd_loss.compute_h_u_from_inner_products(inner_products, gamma_2)
+    h_u_gamma_1 = mkmmd_loss_linear.compute_h_u_from_inner_products_linear(inner_products_linear, gamma_1)
+    h_u_gamma_2 = mkmmd_loss_linear.compute_h_u_from_inner_products_linear(inner_products_linear, gamma_2)
 
     # For each gamma there should be an h_u value per v_i quadruples
     assert h_u_gamma_1.shape == (1, 5)
     assert h_u_gamma_2.shape == (1, 5)
 
     # The fourth entry should coincide with computing h_u(v_4), so we compute h_u using the 4th inner product entry
-    h_u_components_gamma_1_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3]) / 3) / (2 * torch.pow(gamma_1, 2)))
+    h_u_components_gamma_1_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])) / gamma_1)
     # For the other gamma, the fourth entry should coincide with computing h_u(v_4), so we compute h_u using the
     # 4th inner product entry
-    h_u_components_gamma_2_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3]) / 3) / (2 * torch.pow(gamma_2, 2)))
-    h_u_components_gamma_2_0_target = torch.exp((-1 * torch.Tensor([22, 14, 2, 2]) / 3) / (2 * torch.pow(gamma_2, 2)))
+    h_u_components_gamma_2_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])) / gamma_2)
+    h_u_components_gamma_2_0_target = torch.exp((-1 * torch.Tensor([22, 14, 2, 2])) / gamma_2)
 
     h_u_gamma_1_3_target = (
         h_u_components_gamma_1_3_target[0]
@@ -126,56 +180,251 @@ def test_compute_h_u_from_inner_products() -> None:
     assert torch.all(h_u_gamma_2_0_target.eq(h_u_gamma_2[0, 0]))
 
 
-def test_compute_all_h_u_from_inner_products() -> None:
+def test_compute_h_u_from_inner_products() -> None:
+    gamma_1, gamma_2 = torch.Tensor([2]).to(DEVICE), torch.Tensor([1]).to(DEVICE)
+    h_u_gamma_1 = mkmmd_loss.compute_h_u_from_inner_products(inner_products_all, gamma_1)
+    h_u_gamma_2 = mkmmd_loss.compute_h_u_from_inner_products(inner_products_all, gamma_2)
+
+    # For each gamma there should be an h_u value for all possible pairs (x_j, y_j) x (x_k, y_k)
+    # or n_samples x n_samples
+    assert h_u_gamma_1.shape == (1, 11, 11)
+    assert h_u_gamma_2.shape == (1, 11, 11)
+
+    # Looking at the j=3, k=5 entry for gamma_1, this should correspond to the pairs
+    # (x_3, x_5), (y_3, y_5), (x_3, y_5), (y_3, x_5)
+    h_u_components_gamma_1_3_5_target = torch.exp((-1 * torch.Tensor([10, 18, 8, 8])) / gamma_1)
+    # Looking at the j=10, k=4 entry for gamma_1, this should correspond to the pairs
+    # (x_10, x_4), (y_10, y_4), (x_10, y_4), (y_10, x_4)
+    h_u_components_gamma_1_10_4_target = torch.exp((-1 * torch.Tensor([1, 8, 19, 2])) / gamma_1)
+
+    # Looking at the j=0, k=1 entry for gamma_2, this should correspond to the pairs
+    # (x_0, x_1), (y_0, y_1), (x_0, y_1), (y_0, x_1)
+    h_u_components_gamma_2_0_1_target = torch.exp((-1 * torch.Tensor([20, 14, 2, 2])) / gamma_2)
+    # Looking at the j=9, k=4 entry for gamma_2, this should correspond to the pairs
+    # (x_9, x_4), (y_9, y_4), (x_9, y_4), (y_9, x_4)
+    h_u_components_gamma_2_9_4_target = torch.exp((-1 * torch.Tensor([9, 1, 9, 19])) / gamma_2)
+
+    h_u_gamma_1_3_5_target = (
+        h_u_components_gamma_1_3_5_target[0]
+        + h_u_components_gamma_1_3_5_target[1]
+        - h_u_components_gamma_1_3_5_target[2]
+        - h_u_components_gamma_1_3_5_target[3]
+    )
+
+    h_u_gamma_1_10_4_target = (
+        h_u_components_gamma_1_10_4_target[0]
+        + h_u_components_gamma_1_10_4_target[1]
+        - h_u_components_gamma_1_10_4_target[2]
+        - h_u_components_gamma_1_10_4_target[3]
+    )
+
+    h_u_gamma_2_0_1_target = (
+        h_u_components_gamma_2_0_1_target[0]
+        + h_u_components_gamma_2_0_1_target[1]
+        - h_u_components_gamma_2_0_1_target[2]
+        - h_u_components_gamma_2_0_1_target[3]
+    )
+
+    h_u_gamma_2_9_4_target = (
+        h_u_components_gamma_2_9_4_target[0]
+        + h_u_components_gamma_2_9_4_target[1]
+        - h_u_components_gamma_2_9_4_target[2]
+        - h_u_components_gamma_2_9_4_target[3]
+    )
+
+    assert torch.all(h_u_gamma_1_3_5_target.eq(h_u_gamma_1[0, 3, 5]))
+    assert torch.all(h_u_gamma_1_10_4_target.eq(h_u_gamma_1[0, 10, 4]))
+    assert torch.all(h_u_gamma_2_0_1_target.eq(h_u_gamma_2[0, 0, 1]))
+    assert torch.all(h_u_gamma_2_9_4_target.eq(h_u_gamma_2[0, 9, 4]))
+
+
+def test_compute_all_h_u_from_inner_products_linear() -> None:
     # shape should be num_kernels x number v_is
-    assert all_h_us.shape == (3, 5)
-    h_u_gamma_1 = mkmmd_loss.compute_h_u_from_inner_products(inner_products, torch.Tensor([2]).to(DEVICE))
-    h_u_gamma_2 = mkmmd_loss.compute_h_u_from_inner_products(inner_products, torch.Tensor([1]).to(DEVICE))
-    h_u_gamma_3 = mkmmd_loss.compute_h_u_from_inner_products(inner_products, torch.Tensor([0.5]).to(DEVICE))
-    assert torch.all(all_h_us.eq(torch.cat([h_u_gamma_1, h_u_gamma_2, h_u_gamma_3], 0)))
+    assert all_h_us_linear.shape == (3, 5)
+    h_u_gamma_1 = mkmmd_loss_linear.compute_h_u_from_inner_products_linear(
+        inner_products_linear, torch.Tensor([2]).to(DEVICE)
+    )
+    h_u_gamma_2 = mkmmd_loss_linear.compute_h_u_from_inner_products_linear(
+        inner_products_linear, torch.Tensor([1]).to(DEVICE)
+    )
+    h_u_gamma_3 = mkmmd_loss_linear.compute_h_u_from_inner_products_linear(
+        inner_products_linear, torch.Tensor([0.5]).to(DEVICE)
+    )
+    assert torch.all(all_h_us_linear.eq(torch.cat([h_u_gamma_1, h_u_gamma_2, h_u_gamma_3], 0)))
 
     # test run all the way through from X, Y
-    all_h_us_full = mkmmd_loss.compute_all_h_u_per_v_i(X, Y)
-    assert torch.all(all_h_us_full.eq(all_h_us))
+    all_h_us_full = mkmmd_loss_linear.compute_all_h_u_linear(X, Y)
+    assert torch.all(all_h_us_full.eq(all_h_us_linear))
+
+
+def test_compute_all_h_u_from_inner_products() -> None:
+    # shape should be num_kernels x num_samples x num_samples
+    assert all_h_us_all.shape == (3, 11, 11)
+    h_u_gamma_1 = mkmmd_loss.compute_h_u_from_inner_products(inner_products_all, torch.Tensor([2]).to(DEVICE))
+    h_u_gamma_2 = mkmmd_loss.compute_h_u_from_inner_products(inner_products_all, torch.Tensor([1]).to(DEVICE))
+    h_u_gamma_3 = mkmmd_loss.compute_h_u_from_inner_products(inner_products_all, torch.Tensor([0.5]).to(DEVICE))
+    assert torch.all(all_h_us_all.eq(torch.cat([h_u_gamma_1, h_u_gamma_2, h_u_gamma_3])))
+
+    # test run all the way through from X, Y
+    all_h_us_full = mkmmd_loss.compute_all_h_u_all_samples(X, Y)
+    assert torch.all(all_h_us_full.eq(all_h_us_all))
+
+
+def test_compute_hat_d_per_kernel_linear() -> None:
+    # shape should be num_kernels x 1
+    hat_d_per_kernel_linear.shape == (3, 1)
+    assert (
+        pytest.approx(hat_d_per_kernel_linear[0, 0].item(), abs=0.00001)
+        == ((1 / 5) * torch.sum(all_h_us_linear[0, :])).item()
+    )
+    assert (
+        pytest.approx(hat_d_per_kernel_linear[1, 0].item(), abs=0.00001)
+        == ((1 / 5) * torch.sum(all_h_us_linear[1, :])).item()
+    )
+    assert (
+        pytest.approx(hat_d_per_kernel_linear[2, 0].item(), abs=0.00001)
+        == ((1 / 5) * torch.sum(all_h_us_linear[2, :])).item()
+    )
+
+
+def test_compute_mkmmd_linear() -> None:
+    betas = torch.Tensor([1.5, 2.0, -1.0]).reshape(-1, 1).to(DEVICE)
+    mkmmd_target = (
+        hat_d_per_kernel_linear[0, 0] * 1.5
+        + hat_d_per_kernel_linear[1, 0] * 2.0
+        + hat_d_per_kernel_linear[2, 0] * (-1.0)
+    )
+    assert pytest.approx(mkmmd_loss_linear.compute_mkmmd(X, Y, betas), abs=0.0001) == mkmmd_target
 
 
 def test_compute_hat_d_per_kernel() -> None:
-    # shapre should be num_kernels x 1
-    hat_d_per_kernel.shape == (3, 1)
-    assert hat_d_per_kernel[0, 0] == (1 / 5) * (torch.sum(all_h_us[0, :]))
-    assert hat_d_per_kernel[1, 0] == (1 / 5) * (torch.sum(all_h_us[1, :]))
-    assert hat_d_per_kernel[2, 0] == (1 / 5) * (torch.sum(all_h_us[2, :]))
+    # shape should be num_kernels x 1
+    hat_d_per_kernel_all.shape == (3, 1)
+    assert (
+        pytest.approx(hat_d_per_kernel_all[0, 0].item(), abs=0.00001)
+        == ((1 / 121) * torch.sum(all_h_us_all[0, :, :])).item()
+    )
+    assert (
+        pytest.approx(hat_d_per_kernel_all[1, 0].item(), abs=0.00001)
+        == ((1 / 121) * torch.sum(all_h_us_all[1, :, :])).item()
+    )
+    assert (
+        pytest.approx(hat_d_per_kernel_all[2, 0].item(), abs=0.00001)
+        == ((1 / 121) * torch.sum(all_h_us_all[2, :, :])).item()
+    )
 
 
 def test_compute_mkmmd() -> None:
     betas = torch.Tensor([1.5, 2.0, -1.0]).reshape(-1, 1).to(DEVICE)
-    mkmmd_target = hat_d_per_kernel[0, 0] * 1.5 + hat_d_per_kernel[1, 0] * 2.0 + hat_d_per_kernel[2, 0] * (-1.0)
+    mkmmd_target = (
+        hat_d_per_kernel_all[0, 0] * 1.5 + hat_d_per_kernel_all[1, 0] * 2.0 + hat_d_per_kernel_all[2, 0] * (-1.0)
+    )
     assert pytest.approx(mkmmd_loss.compute_mkmmd(X, Y, betas), abs=0.0001) == mkmmd_target
 
 
 def test_create_h_u_delta_w_i() -> None:
     # shape should be num num_kernels x v_is // 2 (noting that we drop the last v_i if uneven number)
     assert h_u_delta_w_i.shape == (3, 2)
-    assert h_u_delta_w_i[0, 0] == all_h_us[0, 0] - all_h_us[0, 1]
-    assert h_u_delta_w_i[0, 1] == all_h_us[0, 2] - all_h_us[0, 3]
-    assert h_u_delta_w_i[1, 0] == all_h_us[1, 0] - all_h_us[1, 1]
-    assert h_u_delta_w_i[1, 1] == all_h_us[1, 2] - all_h_us[1, 3]
-    assert h_u_delta_w_i[2, 0] == all_h_us[2, 0] - all_h_us[2, 1]
-    assert h_u_delta_w_i[2, 1] == all_h_us[2, 2] - all_h_us[2, 3]
+    assert h_u_delta_w_i[0, 0] == all_h_us_linear[0, 0] - all_h_us_linear[0, 1]
+    assert h_u_delta_w_i[0, 1] == all_h_us_linear[0, 2] - all_h_us_linear[0, 3]
+    assert h_u_delta_w_i[1, 0] == all_h_us_linear[1, 0] - all_h_us_linear[1, 1]
+    assert h_u_delta_w_i[1, 1] == all_h_us_linear[1, 2] - all_h_us_linear[1, 3]
+    assert h_u_delta_w_i[2, 0] == all_h_us_linear[2, 0] - all_h_us_linear[2, 1]
+    assert h_u_delta_w_i[2, 1] == all_h_us_linear[2, 2] - all_h_us_linear[2, 3]
 
 
-def test_compute_hat_Q_k() -> None:
+def test_compute_hat_Q_k_linear() -> None:
     # shape should be number of kernels x number of kernels
+    assert Q_k_linear.shape == (3, 3)
+    assert Q_k_linear[0, 0] == (0.5) * (
+        h_u_delta_w_i[0, 0] * h_u_delta_w_i[0, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[0, 1]
+    )
+    assert Q_k_linear[0, 1] == (0.5) * (
+        h_u_delta_w_i[0, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[1, 1]
+    )
+    assert Q_k_linear[1, 0] == (0.5) * (
+        h_u_delta_w_i[0, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[1, 1]
+    )
+    assert Q_k_linear[0, 2] == (0.5) * (
+        h_u_delta_w_i[0, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[2, 1]
+    )
+    assert Q_k_linear[2, 0] == (0.5) * (
+        h_u_delta_w_i[0, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[2, 1]
+    )
+    assert Q_k_linear[1, 1] == (0.5) * (
+        h_u_delta_w_i[1, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[1, 1]
+    )
+    assert Q_k_linear[1, 2] == (0.5) * (
+        h_u_delta_w_i[1, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[2, 1]
+    )
+    assert Q_k_linear[2, 1] == (0.5) * (
+        h_u_delta_w_i[1, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[2, 1]
+    )
+    assert Q_k_linear[2, 2] == (0.5) * (
+        h_u_delta_w_i[2, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[2, 1] * h_u_delta_w_i[2, 1]
+    )
+
+
+def test_form_kernel_samples_minus_expectation() -> None:
+    assert kernel_samples_minus_expectation.shape == (3, 11, 11)
+
+    kernel_samples_minus_expectation_0_3_5 = all_h_us_all[0, 3, 5] - hat_d_per_kernel_all[0, 0]
+    kernel_samples_minus_expectation_1_3_5 = all_h_us_all[1, 3, 5] - hat_d_per_kernel_all[1, 0]
+    kernel_samples_minus_expectation_2_0_1 = all_h_us_all[2, 0, 1] - hat_d_per_kernel_all[2, 0]
+
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_0_3_5, abs=0.00001) == kernel_samples_minus_expectation[0, 3, 5]
+    )
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_1_3_5, abs=0.00001) == kernel_samples_minus_expectation[1, 3, 5]
+    )
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_2_0_1, abs=0.00001) == kernel_samples_minus_expectation[2, 0, 1]
+    )
+
+    kernel_samples_minus_expectation_0_7_2 = all_h_us_all[0, 7, 2] - hat_d_per_kernel_all[0, 0]
+    kernel_samples_minus_expectation_1_9_1 = all_h_us_all[1, 9, 1] - hat_d_per_kernel_all[1, 0]
+    kernel_samples_minus_expectation_2_1_1 = all_h_us_all[2, 1, 1] - hat_d_per_kernel_all[2, 0]
+
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_0_7_2, abs=0.00001) == kernel_samples_minus_expectation[0, 7, 2]
+    )
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_1_9_1, abs=0.00001) == kernel_samples_minus_expectation[1, 9, 1]
+    )
+    assert (
+        pytest.approx(kernel_samples_minus_expectation_2_1_1, abs=0.00001) == kernel_samples_minus_expectation[2, 1, 1]
+    )
+
+
+def unrolled_summation(kernel_1_index: int, kernel_2_index: int) -> torch.Tensor:
+    sum = torch.Tensor([0.0]).to(DEVICE)
+    for i in range(11):
+        for j in range(11):
+            sum += (
+                kernel_samples_minus_expectation[kernel_1_index][i][j]
+                * kernel_samples_minus_expectation[kernel_2_index][i][j]
+            )
+    return sum
+
+
+def test_compute_Q_k() -> None:
     assert Q_k.shape == (3, 3)
-    assert Q_k[0, 0] == (0.5) * (h_u_delta_w_i[0, 0] * h_u_delta_w_i[0, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[0, 1])
-    assert Q_k[0, 1] == (0.5) * (h_u_delta_w_i[0, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[1, 1])
-    assert Q_k[1, 0] == (0.5) * (h_u_delta_w_i[0, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[1, 1])
-    assert Q_k[0, 2] == (0.5) * (h_u_delta_w_i[0, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[2, 1])
-    assert Q_k[2, 0] == (0.5) * (h_u_delta_w_i[0, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[0, 1] * h_u_delta_w_i[2, 1])
-    assert Q_k[1, 1] == (0.5) * (h_u_delta_w_i[1, 0] * h_u_delta_w_i[1, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[1, 1])
-    assert Q_k[1, 2] == (0.5) * (h_u_delta_w_i[1, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[2, 1])
-    assert Q_k[2, 1] == (0.5) * (h_u_delta_w_i[1, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[1, 1] * h_u_delta_w_i[2, 1])
-    assert Q_k[2, 2] == (0.5) * (h_u_delta_w_i[2, 0] * h_u_delta_w_i[2, 0] + h_u_delta_w_i[2, 1] * h_u_delta_w_i[2, 1])
+
+    Q_k_0_0 = (1 / (121 - 1)) * unrolled_summation(0, 0)
+    Q_k_1_0 = (1 / (121 - 1)) * unrolled_summation(1, 0)
+    Q_k_0_1 = (1 / (121 - 1)) * unrolled_summation(0, 1)
+    Q_k_1_2 = (1 / (121 - 1)) * unrolled_summation(1, 2)
+    Q_k_2_1 = (1 / (121 - 1)) * unrolled_summation(2, 1)
+    # Should be symmetric
+    pytest.approx(Q_k_1_0, abs=0.00001) == Q_k_0_1
+    pytest.approx(Q_k_1_2, abs=0.00001) == Q_k_2_1
+
+    pytest.approx(Q_k[0, 0], abs=0.00001) == Q_k_0_0
+    pytest.approx(Q_k[1, 0], abs=0.00001) == Q_k_1_0
+    pytest.approx(Q_k[0, 1], abs=0.00001) == Q_k_0_1
+    pytest.approx(Q_k[1, 2], abs=0.00001) == Q_k_1_2
+    pytest.approx(Q_k[2, 1], abs=0.00001) == Q_k_2_1
 
 
 def test_beta_with_largest_hat_d() -> None:
@@ -206,12 +455,16 @@ def test_beta_with_largest_hat_d() -> None:
     assert torch.all(one_hot_beta_min.eq(beta_target_min))
 
 
-def test_optimize_betas_degenerate_case() -> None:
-    # The simple test cases above result in a set of hat_ds that are all negative. In this case, we perform the
-    # selection of a single kernel as recommended in Gretton
-    degenerate_betas = mkmmd_loss.optimize_betas(X, Y, lambda_m=0.0001)
-    beta_target = torch.Tensor([[0, 1, 0]]).to(DEVICE).t()
+def test_optimize_betas_for_X_Y() -> None:
+    # The simple test cases above result in a set of hat_ds that are all negative for the linear estimate. In this
+    # case, we perform the selection of a single kernel as recommended in Gretton
+    degenerate_betas = mkmmd_loss_linear.optimize_betas(X, Y, lambda_m=0.0001)
+    beta_target = torch.Tensor([[1, 0, 0]]).to(DEVICE).t()
     assert torch.all(degenerate_betas.eq(beta_target))
+
+    non_degenerate_beta = mkmmd_loss.optimize_betas(X, Y, lambda_m=0.0001)
+    beta_target = torch.Tensor([[0, 0, 1.0]]).to(DEVICE).t()
+    assert torch.allclose(non_degenerate_beta, beta_target, rtol=0, atol=1e-7)
 
 
 def test_gamma_defaults() -> None:
@@ -227,22 +480,21 @@ def test_gamma_defaults() -> None:
 
 def test_get_best_vertex_for_objective_function() -> None:
     lambda_m = 0.0001
-    regularized_Q_k = 2 * Q_k + lambda_m * torch.eye(3).to(DEVICE)
-    best_vertex = mkmmd_loss.get_best_vertex_for_objective_function(hat_d_per_kernel, regularized_Q_k)
-    print(hat_d_per_kernel)
-    print(regularized_Q_k)
+    regularized_Q_k = 2 * Q_k_linear + lambda_m * torch.eye(3).to(DEVICE)
+    best_vertex = mkmmd_loss_linear.get_best_vertex_for_objective_function(hat_d_per_kernel_linear, regularized_Q_k)
     assert best_vertex.shape == (3, 1)
-    # check this
-    assert pytest.approx(best_vertex[0, 0].item(), abs=0.0001) == -4.1297
+
+    assert pytest.approx(best_vertex[0, 0].item(), abs=0.0001) == -4.1689
     assert pytest.approx(best_vertex[1, 0].item(), abs=0.0001) == 0.0
     assert pytest.approx(best_vertex[2, 0].item(), abs=0.0001) == 0.0
-    assert pytest.approx(torch.mm(hat_d_per_kernel.t(), best_vertex), abs=0.0001) == 1.0
+    assert pytest.approx(torch.mm(hat_d_per_kernel_linear.t(), best_vertex), abs=0.0001) == 1.0
 
 
-def test_optimizer_betas_in_non_degenerate_case() -> None:
+def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
     lambda_m = 0.0001
     torch.manual_seed(42)
-    default_mkmmd = MkMmdLoss(DEVICE)
+    default_mkmmd = MkMmdLoss(DEVICE, perform_linear_approximation=True)
+
     # First sample is from a zero mean gaussian with unit covariance (dimension 5)
     p = MultivariateNormal(torch.zeros(5), torch.eye(5))
     X = p.sample(
@@ -252,6 +504,7 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
             ]
         )
     )
+
     # Second sample is a mixture of two gaussian with zero mean except the first has mean 1.0 in the first coordinate
     # and the second has mean 1.0 in the second coordinate
     q_1 = MultivariateNormal(torch.tensor([1.0, 0, 0, 0, 0]), torch.eye(5))
@@ -272,23 +525,87 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
             )
         )
     ) / 2.0
-    all_h_u_per_vi_local = default_mkmmd.compute_all_h_u_per_v_i(X, Y)
+    all_h_u_per_vi_local = default_mkmmd.compute_all_h_u_linear(X, Y)
     hat_d_per_kernel_local = default_mkmmd.compute_hat_d_per_kernel(all_h_u_per_vi_local)
     mkmmd_before_opt = default_mkmmd(X, Y)
-    assert pytest.approx(mkmmd_before_opt.item(), abs=0.0001) == 0.01928
+    target_mkmmd = torch.mm(default_mkmmd.betas.t(), hat_d_per_kernel_local)[0][0]
+    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd
 
-    hat_Q_k = default_mkmmd.compute_hat_Q_k(all_h_u_per_vi_local)
+    hat_Q_k = default_mkmmd.compute_hat_Q_k_linear(all_h_u_per_vi_local)
     regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19)).to(DEVICE)
-    unnormalized_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
-    unnormalized_betas = torch.clamp(unnormalized_betas, min=0)
-    assert pytest.approx(torch.mm(unnormalized_betas.t(), hat_d_per_kernel_local), abs=0.0001) == 1.0000
+    raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
+    raw_betas = torch.clamp(raw_betas, min=0)
+    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local), abs=0.0001) == 1.0000
 
     betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
-    assert torch.all(betas_local.eq((1 / torch.sum(unnormalized_betas)) * unnormalized_betas))
+    assert torch.all(betas_local.eq((1 / torch.sum(raw_betas)) * raw_betas))
+
+    default_mkmmd = MkMmdLoss(DEVICE, minimize_type_two_error=False, perform_linear_approximation=True)
+    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    one_hot_betas = torch.zeros_like(betas_local)
+
+    one_hot_betas[0, 0] = 1
+    assert torch.all(betas_local.eq(one_hot_betas))
+
+
+def test_optimizer_betas_in_non_degenerate_case() -> None:
+    lambda_m = 0.0001
+    torch.manual_seed(42)
+    default_mkmmd = MkMmdLoss(DEVICE)
+
+    # First sample is from a zero mean gaussian with unit covariance (dimension 5)
+    p = MultivariateNormal(torch.zeros(5), torch.eye(5))
+    X = p.sample(
+        torch.Size(
+            [
+                100,
+            ]
+        )
+    )
+
+    # Second sample is a mixture of two gaussian with zero mean except the first has mean 1.0 in the first coordinate
+    # and the second has mean 1.0 in the second coordinate
+    q_1 = MultivariateNormal(torch.tensor([1.0, 0, 0, 0, 0]), torch.eye(5))
+    q_2 = MultivariateNormal(torch.tensor([0, 1.0, 0, 0, 0]), torch.eye(5))
+    Y = (
+        q_1.sample(
+            torch.Size(
+                [
+                    100,
+                ]
+            )
+        )
+        + q_2.sample(
+            torch.Size(
+                [
+                    100,
+                ]
+            )
+        )
+    ) / 2.0
+
+    all_h_u_per_sample = default_mkmmd.compute_all_h_u_all_samples(X, Y)
+    hat_d_per_kernel_local = default_mkmmd.compute_hat_d_per_kernel(all_h_u_per_sample)
+    mkmmd_before_opt = default_mkmmd(X, Y)
+    target_mkmmd = torch.mm(default_mkmmd.betas.t(), hat_d_per_kernel_local)[0][0]
+    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd
+
+    hat_Q_k = default_mkmmd.compute_hat_Q_k(all_h_u_per_sample, hat_d_per_kernel_local)
+    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19)).to(DEVICE)
+    raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
+    raw_betas = torch.clamp(raw_betas, min=0)
+    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local), abs=0.0001) == 1.0000
+
+    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    assert torch.all(betas_local.eq((1 / torch.sum(raw_betas)) * raw_betas))
+
+    default_mkmmd.betas = betas_local
+    mkmmd_after_opt = default_mkmmd(X, Y)
+    assert mkmmd_after_opt.item() > mkmmd_before_opt.item()
 
     default_mkmmd = MkMmdLoss(DEVICE, minimize_type_two_error=False)
     betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
     one_hot_betas = torch.zeros_like(betas_local)
-    # check this
-    one_hot_betas[0, 0] = 1
+
+    one_hot_betas[1, 0] = 1
     assert torch.all(betas_local.eq(one_hot_betas))


### PR DESCRIPTION
# PR Type
Other

# Short Description

This PR adds tests for the MK-MMD loss updates suggested in the target PR. The tests modify both the original MK-MMD tests associated with the linear approximation and adds tests to cover the full approximation calculations constructed in the update. 

I also did some structural refactors to sort of "split" the linear vs. full approximation processing where I thought it made sense. Let me know if you disagree with any of it.

# Tests Added

See above.
