### PR TITLE
Update flwr 1.7 to 1.9

### DIFF
--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -41,5 +41,3 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.8
         with:
           virtual-environment: .venv/
-          ignore-vulns: |
-            GHSA-cqh9-jfqr-h9jj

--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -45,7 +45,4 @@ jobs:
           # because flwr 1.7 depends on them. Opening an issue
           # with flwr. Likely can remove this in flwr 1.8.
           ignore-vulns: |
-            GHSA-3ww4-gg4f-jr7f
-            GHSA-9v9h-cgj8-h64p
-            GHSA-6vqw-3v5j-54x4
             GHSA-cqh9-jfqr-h9jj

--- a/.github/workflows/static_code_checks.yaml
+++ b/.github/workflows/static_code_checks.yaml
@@ -41,8 +41,5 @@ jobs:
         uses: pypa/gh-action-pip-audit@v1.0.8
         with:
           virtual-environment: .venv/
-          # ignoring security vulnerabilities in cryptography
-          # because flwr 1.7 depends on them. Opening an issue
-          # with flwr. Likely can remove this in flwr 1.8.
           ignore-vulns: |
             GHSA-cqh9-jfqr-h9jj

--- a/fl4health/server/base_server.py
+++ b/fl4health/server/base_server.py
@@ -59,10 +59,10 @@ class FlServer(Server):
         else:
             self.metrics_reporter = MetricsReporter()
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         self.metrics_reporter.add_to_metrics({"type": "server", "fit_start": datetime.datetime.now()})
 
-        history, elapsed_time = super().fit(num_rounds, timeout)
+        history = super().fit(num_rounds, timeout)
         if self.wandb_reporter:
             # report history to W and B
             self.wandb_reporter.report_metrics(num_rounds, history)
@@ -75,7 +75,7 @@ class FlServer(Server):
             }
         )
 
-        return history, elapsed_time
+        return history
 
     def fit_round(
         self,
@@ -251,7 +251,9 @@ class FlServer(Server):
         )
         # Collect `evaluate` results from all clients participating in this round
         results, failures = evaluate_clients(
-            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=server_round
+            client_instructions,
+            max_workers=self.max_workers,
+            timeout=timeout,
         )
         log(
             DEBUG,

--- a/fl4health/server/base_server.py
+++ b/fl4health/server/base_server.py
@@ -59,10 +59,10 @@ class FlServer(Server):
         else:
             self.metrics_reporter = MetricsReporter()
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         self.metrics_reporter.add_to_metrics({"type": "server", "fit_start": datetime.datetime.now()})
 
-        history = super().fit(num_rounds, timeout)
+        history, elapsed_time = super().fit(num_rounds, timeout)
         if self.wandb_reporter:
             # report history to W and B
             self.wandb_reporter.report_metrics(num_rounds, history)
@@ -75,7 +75,7 @@ class FlServer(Server):
             }
         )
 
-        return history
+        return history, elapsed_time
 
     def fit_round(
         self,
@@ -251,9 +251,7 @@ class FlServer(Server):
         )
         # Collect `evaluate` results from all clients participating in this round
         results, failures = evaluate_clients(
-            client_instructions,
-            max_workers=self.max_workers,
-            timeout=timeout,
+            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=server_round
         )
         log(
             DEBUG,

--- a/fl4health/server/base_server.py
+++ b/fl4health/server/base_server.py
@@ -60,6 +60,19 @@ class FlServer(Server):
             self.metrics_reporter = MetricsReporter()
 
     def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+        """
+        Run federated learning for a number of rounds.
+
+        Args:
+            num_rounds (int): Number of server rounds to run.
+            timeout (Optional[float]): The amount of time in seconds that the server will wait for results from the
+                clients selected to participate in federated training.
+
+        Returns:
+            Tuple[History, float]: The first element of the tuple is a history object containing the full set of
+                FL training results, including things like aggregated loss and metrics.
+                Tuple also contains the elapsed time in seconds for the round.
+        """
         self.metrics_reporter.add_to_metrics({"type": "server", "fit_start": datetime.datetime.now()})
 
         history, elapsed_time = super().fit(num_rounds, timeout)
@@ -250,6 +263,7 @@ class FlServer(Server):
             self._client_manager.num_available(),
         )
         # Collect `evaluate` results from all clients participating in this round
+        # flwr sets group_id to server_round by default, so we follow that convention
         results, failures = evaluate_clients(
             client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=server_round
         )

--- a/fl4health/server/client_level_dp_fed_avg_server.py
+++ b/fl4health/server/client_level_dp_fed_avg_server.py
@@ -71,8 +71,8 @@ class ClientLevelDPFedAvgServer(FlServer):
 
         Returns:
             Tuple[History, float]: The first element of the tuple is a history object containing the full set of
-            FL training results, including things like aggregated loss and metrics.
-            Tuple also contains the elapsed time in seconds for the round.
+                FL training results, including things like aggregated loss and metrics.
+                Tuple also contains the elapsed time in seconds for the round.
         """
 
         assert isinstance(self.strategy, ClientLevelDPFedAvgM)

--- a/fl4health/server/client_level_dp_fed_avg_server.py
+++ b/fl4health/server/client_level_dp_fed_avg_server.py
@@ -1,6 +1,6 @@
 from logging import INFO
 from math import ceil
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
@@ -60,7 +60,7 @@ class ClientLevelDPFedAvgServer(FlServer):
         self.num_server_rounds = num_server_rounds
         self.delta = delta
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """
         Run federated averaging for a number of rounds.
 
@@ -70,9 +70,8 @@ class ClientLevelDPFedAvgServer(FlServer):
                 clients selected to participate in federated training.
 
         Returns:
-            Tuple[History, float]: The first element of the tuple is a history object containing the full set of
-            FL training results, including things like aggregated loss and metrics.
-            Tuple also contains the elapsed time in seconds for the round.
+            History: The history object contains the full set of FL training results, including things like aggregated
+                loss and metrics.
         """
 
         assert isinstance(self.strategy, ClientLevelDPFedAvgM)

--- a/fl4health/server/client_level_dp_fed_avg_server.py
+++ b/fl4health/server/client_level_dp_fed_avg_server.py
@@ -1,6 +1,6 @@
 from logging import INFO
 from math import ceil
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
@@ -60,7 +60,7 @@ class ClientLevelDPFedAvgServer(FlServer):
         self.num_server_rounds = num_server_rounds
         self.delta = delta
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Run federated averaging for a number of rounds.
 
@@ -70,8 +70,9 @@ class ClientLevelDPFedAvgServer(FlServer):
                 clients selected to participate in federated training.
 
         Returns:
-            History: The history object contains the full set of FL training results, including things like aggregated
-                loss and metrics.
+            Tuple[History, float]: The first element of the tuple is a history object containing the full set of
+            FL training results, including things like aggregated loss and metrics.
+            Tuple also contains the elapsed time in seconds for the round.
         """
 
         assert isinstance(self.strategy, ClientLevelDPFedAvgM)

--- a/fl4health/server/evaluate_server.py
+++ b/fl4health/server/evaluate_server.py
@@ -152,7 +152,7 @@ class EvaluateServer(Server):
 
         # Collect `evaluate` results from all clients participating in this round
         results, failures = evaluate_clients(
-            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=None
+            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=0
         )
         log(INFO, f"Federated Evaluation received {len(results)} results and {len(failures)} failures")
 

--- a/fl4health/server/evaluate_server.py
+++ b/fl4health/server/evaluate_server.py
@@ -78,7 +78,7 @@ class EvaluateServer(Server):
         log(INFO, "Model loaded and state converted to parameters")
         return parameters
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         In order to head off training and only run eval, we have to override the fit function as this is
         essentially the entry point for federated learning from the app.
@@ -89,7 +89,8 @@ class EvaluateServer(Server):
                 If none, then it will wait for the minimum number to respond indefinitely.
 
         Returns:
-            History: This object will hold the aggregated metrics returned from the clients.
+            Tuple[History, float]: The first element of the tuple is a History object containing the aggregated
+                metrics returned from the clients. Tuple also contains elapsed time in seconds for round.
         """
         self.metrics_reporter.add_to_metrics({"type": "server", "fit_start": datetime.datetime.now()})
 
@@ -117,7 +118,7 @@ class EvaluateServer(Server):
         end_time = timeit.default_timer()
         elapsed = end_time - start_time
         log(INFO, "Federated Evaluation Finished in %s", elapsed)
-        return history
+        return history, elapsed
 
     def federated_evaluate(
         self,
@@ -151,9 +152,7 @@ class EvaluateServer(Server):
 
         # Collect `evaluate` results from all clients participating in this round
         results, failures = evaluate_clients(
-            client_instructions,
-            max_workers=self.max_workers,
-            timeout=timeout,
+            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=None
         )
         log(INFO, f"Federated Evaluation received {len(results)} results and {len(failures)} failures")
 

--- a/fl4health/server/evaluate_server.py
+++ b/fl4health/server/evaluate_server.py
@@ -78,7 +78,7 @@ class EvaluateServer(Server):
         log(INFO, "Model loaded and state converted to parameters")
         return parameters
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """
         In order to head off training and only run eval, we have to override the fit function as this is
         essentially the entry point for federated learning from the app.
@@ -89,8 +89,7 @@ class EvaluateServer(Server):
                 If none, then it will wait for the minimum number to respond indefinitely.
 
         Returns:
-            Tuple[History, float]: The first element of the tuple is a History object containing the aggregated
-                metrics returned from the clients. Tuple also contains elapsed time in seconds for round.
+            History: This object will hold the aggregated metrics returned from the clients.
         """
         self.metrics_reporter.add_to_metrics({"type": "server", "fit_start": datetime.datetime.now()})
 
@@ -118,7 +117,7 @@ class EvaluateServer(Server):
         end_time = timeit.default_timer()
         elapsed = end_time - start_time
         log(INFO, "Federated Evaluation Finished in %s", elapsed)
-        return history, elapsed
+        return history
 
     def federated_evaluate(
         self,
@@ -152,7 +151,9 @@ class EvaluateServer(Server):
 
         # Collect `evaluate` results from all clients participating in this round
         results, failures = evaluate_clients(
-            client_instructions, max_workers=self.max_workers, timeout=timeout, group_id=None
+            client_instructions,
+            max_workers=self.max_workers,
+            timeout=timeout,
         )
         log(INFO, f"Federated Evaluation received {len(results)} results and {len(failures)} failures")
 

--- a/fl4health/server/instance_level_dp_server.py
+++ b/fl4health/server/instance_level_dp_server.py
@@ -1,6 +1,6 @@
 from logging import INFO
 from math import ceil
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
@@ -78,7 +78,7 @@ class InstanceLevelDpServer(FlServer):
         self.num_server_rounds = num_server_rounds
         self.delta = delta
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """
         Run federated averaging for a number of rounds.
 
@@ -88,9 +88,8 @@ class InstanceLevelDpServer(FlServer):
                 clients selected to participate in federated training.
 
         Returns:
-            Tuple[History, float]: The first element of the tuple is a history object containing the full
-                set of FL training results, including things like aggregated loss and metrics.
-                Tuple also includes elapsed time in seconds for round.
+            History: The history object contains the full set of FL training results, including things like aggregated
+                loss and metrics.
         """
 
         assert isinstance(self.strategy, StrategyWithPolling)

--- a/fl4health/server/instance_level_dp_server.py
+++ b/fl4health/server/instance_level_dp_server.py
@@ -1,6 +1,6 @@
 from logging import INFO
 from math import ceil
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from flwr.common.logger import log
 from flwr.server.client_manager import ClientManager
@@ -78,7 +78,7 @@ class InstanceLevelDpServer(FlServer):
         self.num_server_rounds = num_server_rounds
         self.delta = delta
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Run federated averaging for a number of rounds.
 
@@ -88,8 +88,9 @@ class InstanceLevelDpServer(FlServer):
                 clients selected to participate in federated training.
 
         Returns:
-            History: The history object contains the full set of FL training results, including things like aggregated
-                loss and metrics.
+            Tuple[History, float]: The first element of the tuple is a history object containing the full
+                set of FL training results, including things like aggregated loss and metrics.
+                Tuple also includes elapsed time in seconds for round.
         """
 
         assert isinstance(self.strategy, StrategyWithPolling)

--- a/fl4health/server/polling.py
+++ b/fl4health/server/polling.py
@@ -57,7 +57,7 @@ def poll_client(client: ClientProxy, ins: GetPropertiesIns) -> Tuple[ClientProxy
     Returns:
         Tuple[ClientProxy, GetPropertiesRes]: Returns the resulting properties from the client response.
     """
-    property_res: GetPropertiesRes = client.get_properties(ins=ins, timeout=None, group_id=None)
+    property_res: GetPropertiesRes = client.get_properties(ins=ins, timeout=None)
     return client, property_res
 
 

--- a/fl4health/server/polling.py
+++ b/fl4health/server/polling.py
@@ -57,7 +57,7 @@ def poll_client(client: ClientProxy, ins: GetPropertiesIns) -> Tuple[ClientProxy
     Returns:
         Tuple[ClientProxy, GetPropertiesRes]: Returns the resulting properties from the client response.
     """
-    property_res: GetPropertiesRes = client.get_properties(ins=ins, timeout=None)
+    property_res: GetPropertiesRes = client.get_properties(ins=ins, timeout=None, group_id=None)
     return client, property_res
 
 

--- a/fl4health/server/scaffold_server.py
+++ b/fl4health/server/scaffold_server.py
@@ -68,7 +68,7 @@ class ScaffoldServer(FlServer):
                 initialize the models of all clients. Timeout defines how long to wait for a response.
 
         Returns:
-            Parameters: Initialed parameters (model weights and control variates).
+            Parameters: Initial parameters (model weights and control variates).
         """
         assert isinstance(self.strategy, Scaffold)
         # First run basic parameter initialization from the parent server

--- a/fl4health/server/scaffold_server.py
+++ b/fl4health/server/scaffold_server.py
@@ -1,5 +1,5 @@
 from logging import DEBUG, ERROR, INFO
-from typing import Optional
+from typing import Optional, Tuple
 
 from flwr.common import Parameters, ndarrays_to_parameters, parameters_to_ndarrays
 from flwr.common.logger import log
@@ -53,7 +53,7 @@ class ScaffoldServer(FlServer):
         )
         self.warm_start = warm_start
 
-    def _get_initial_parameters(self, timeout: Optional[float]) -> Parameters:
+    def _get_initial_parameters(self, server_round: int, timeout: Optional[float]) -> Parameters:
         """
         Overrides the _get_initial_parameters in the flwr server base class to strap on the possibility of a
         warm_start for SCAFFOLD. Initializes parameters (models weights and control variates) of the server.
@@ -62,13 +62,17 @@ class ScaffoldServer(FlServer):
         weights are discarded.
 
         Args:
+            server_round (int): The current server round.
             timeout (Optional[float]): If the server strategy object does not have a server-side initial parameters
                 function defined, then one of the clients is polled and their model parameters are returned in order to
                 initialize the models of all clients. Timeout defines how long to wait for a response.
+
+        Returns:
+            Parameters: Initialed parameters (model weights and control variates).
         """
         assert isinstance(self.strategy, Scaffold)
         # First run basic parameter initialization from the parent server
-        initial_parameters = super()._get_initial_parameters(timeout=timeout)
+        initial_parameters = super()._get_initial_parameters(server_round, timeout=timeout)
 
         # If warm_start, run routine to initialize control variates without updating global model
         # control variates are initialized as average local gradient over training steps
@@ -87,7 +91,7 @@ class ScaffoldServer(FlServer):
                     clients (out of {self._client_manager.num_available()})",
                 )
 
-                results, failures = fit_clients(client_instructions, self.max_workers, timeout)
+                results, failures = fit_clients(client_instructions, self.max_workers, timeout, group_id=server_round)
 
                 log(
                     DEBUG,
@@ -114,7 +118,7 @@ class ScaffoldServer(FlServer):
 
         return initial_parameters
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Run the SCAFFOLD FL algorithm for a fixed number of rounds. This overrides the base server fit class just to
         ensure that the provided strategy is a Scaffold strategy object before proceeding.
@@ -126,8 +130,9 @@ class ScaffoldServer(FlServer):
                 server waits for the minimum number of clients to be available set in the strategy.
 
         Returns:
-            History: The history object contains the full set of FL training results, including things like aggregated
-                loss and metrics.
+            Tuple[History, float]: The first element of the tuple is a history object containing the full set of
+                FL training results, including things like aggregated loss and metrics.
+                Tuple also includes elapsed time in seconds for round.
         """
         assert isinstance(self.strategy, Scaffold)
         return super().fit(num_rounds=num_rounds, timeout=timeout)
@@ -205,7 +210,7 @@ class DPScaffoldServer(ScaffoldServer, InstanceLevelDpServer):
             num_server_rounds=num_server_rounds,
         )
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Run DP Scaffold algorithm for the specified number of rounds.
 
@@ -216,8 +221,9 @@ class DPScaffoldServer(ScaffoldServer, InstanceLevelDpServer):
                 server waits for the minimum number of clients to be available set in the strategy.
 
         Returns:
-            History: The history object contains the full set of FL training results, including things like aggregated
-                loss and metrics.
+            Tuple[History, float]: First element of tuple is history object containing the full set of FL
+                training results, including aggregated loss and metrics.
+                Tuple also includes the elapsed time in seconds for round.
         """
         assert isinstance(self.strategy, Scaffold)
         # Now that we initialized the parameters for scaffold, call instance level privacy fit

--- a/fl4health/server/scaffold_server.py
+++ b/fl4health/server/scaffold_server.py
@@ -1,5 +1,5 @@
 from logging import DEBUG, ERROR, INFO
-from typing import Optional, Tuple
+from typing import Optional
 
 from flwr.common import Parameters, ndarrays_to_parameters, parameters_to_ndarrays
 from flwr.common.logger import log
@@ -53,7 +53,7 @@ class ScaffoldServer(FlServer):
         )
         self.warm_start = warm_start
 
-    def _get_initial_parameters(self, server_round: int, timeout: Optional[float]) -> Parameters:
+    def _get_initial_parameters(self, timeout: Optional[float]) -> Parameters:
         """
         Overrides the _get_initial_parameters in the flwr server base class to strap on the possibility of a
         warm_start for SCAFFOLD. Initializes parameters (models weights and control variates) of the server.
@@ -62,17 +62,13 @@ class ScaffoldServer(FlServer):
         weights are discarded.
 
         Args:
-            server_round (int): The current server round.
             timeout (Optional[float]): If the server strategy object does not have a server-side initial parameters
                 function defined, then one of the clients is polled and their model parameters are returned in order to
                 initialize the models of all clients. Timeout defines how long to wait for a response.
-
-        Returns:
-            Parameters: Initialed parameters (model weights and control variates).
         """
         assert isinstance(self.strategy, Scaffold)
         # First run basic parameter initialization from the parent server
-        initial_parameters = super()._get_initial_parameters(server_round, timeout=timeout)
+        initial_parameters = super()._get_initial_parameters(timeout=timeout)
 
         # If warm_start, run routine to initialize control variates without updating global model
         # control variates are initialized as average local gradient over training steps
@@ -91,7 +87,7 @@ class ScaffoldServer(FlServer):
                     clients (out of {self._client_manager.num_available()})",
                 )
 
-                results, failures = fit_clients(client_instructions, self.max_workers, timeout, group_id=server_round)
+                results, failures = fit_clients(client_instructions, self.max_workers, timeout)
 
                 log(
                     DEBUG,
@@ -118,7 +114,7 @@ class ScaffoldServer(FlServer):
 
         return initial_parameters
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """
         Run the SCAFFOLD FL algorithm for a fixed number of rounds. This overrides the base server fit class just to
         ensure that the provided strategy is a Scaffold strategy object before proceeding.
@@ -130,9 +126,8 @@ class ScaffoldServer(FlServer):
                 server waits for the minimum number of clients to be available set in the strategy.
 
         Returns:
-            Tuple[History, float]: The first element of the tuple is a history object containing the full set of
-                FL training results, including things like aggregated loss and metrics.
-                Tuple also includes elapsed time in seconds for round.
+            History: The history object contains the full set of FL training results, including things like aggregated
+                loss and metrics.
         """
         assert isinstance(self.strategy, Scaffold)
         return super().fit(num_rounds=num_rounds, timeout=timeout)
@@ -210,7 +205,7 @@ class DPScaffoldServer(ScaffoldServer, InstanceLevelDpServer):
             num_server_rounds=num_server_rounds,
         )
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """
         Run DP Scaffold algorithm for the specified number of rounds.
 
@@ -221,9 +216,8 @@ class DPScaffoldServer(ScaffoldServer, InstanceLevelDpServer):
                 server waits for the minimum number of clients to be available set in the strategy.
 
         Returns:
-            Tuple[History, float]: First element of tuple is history object containing the full set of FL
-                training results, including aggregated loss and metrics.
-                Tuple also includes the elapsed time in seconds for round.
+            History: The history object contains the full set of FL training results, including things like aggregated
+                loss and metrics.
         """
         assert isinstance(self.strategy, Scaffold)
         # Now that we initialized the parameters for scaffold, call instance level privacy fit

--- a/fl4health/server/tabular_feature_alignment_server.py
+++ b/fl4health/server/tabular_feature_alignment_server.py
@@ -79,13 +79,13 @@ class TabularFeatureAlignmentServer(FlServer):
         self.dimension_info[INPUT_DIMENSION] = input_dimension
         self.dimension_info[OUTPUT_DIMENSION] = output_dimension
 
-    def _get_initial_parameters(self, timeout: Optional[float]) -> Parameters:
+    def _get_initial_parameters(self, server_round: int, timeout: Optional[float]) -> Parameters:
         assert INPUT_DIMENSION in self.dimension_info and OUTPUT_DIMENSION in self.dimension_info
         input_dimension = self.dimension_info[INPUT_DIMENSION]
         output_dimension = self.dimension_info[OUTPUT_DIMENSION]
         return self.initialize_parameters(input_dimension, output_dimension)
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """Run federated averaging for a number of rounds."""
         assert isinstance(self.strategy, BasicFedAvg)
 

--- a/fl4health/server/tabular_feature_alignment_server.py
+++ b/fl4health/server/tabular_feature_alignment_server.py
@@ -79,13 +79,13 @@ class TabularFeatureAlignmentServer(FlServer):
         self.dimension_info[INPUT_DIMENSION] = input_dimension
         self.dimension_info[OUTPUT_DIMENSION] = output_dimension
 
-    def _get_initial_parameters(self, server_round: int, timeout: Optional[float]) -> Parameters:
+    def _get_initial_parameters(self, timeout: Optional[float]) -> Parameters:
         assert INPUT_DIMENSION in self.dimension_info and OUTPUT_DIMENSION in self.dimension_info
         input_dimension = self.dimension_info[INPUT_DIMENSION]
         output_dimension = self.dimension_info[OUTPUT_DIMENSION]
         return self.initialize_parameters(input_dimension, output_dimension)
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
         """Run federated averaging for a number of rounds."""
         assert isinstance(self.strategy, BasicFedAvg)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -853,47 +853,56 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "41.0.7"
+version = "42.0.8"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf"},
-    {file = "cryptography-41.0.7-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a"},
-    {file = "cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157"},
-    {file = "cryptography-41.0.7-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406"},
-    {file = "cryptography-41.0.7-cp37-abi3-win32.whl", hash = "sha256:f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d"},
-    {file = "cryptography-41.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:079b85658ea2f59c4f43b70f8119a52414cdb7be34da5d019a77bf96d473b960"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:b640981bf64a3e978a56167594a0e97db71c89a479da8e175d8bb5be5178c003"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e3114da6d7f95d2dee7d3f4eec16dacff819740bbab931aff8648cb13c5ff5e7"},
-    {file = "cryptography-41.0.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d5ec85080cce7b0513cfd233914eb8b7bbd0633f1d1703aa28d1dd5a72f678ec"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7a698cb1dac82c35fcf8fe3417a3aaba97de16a01ac914b89a0889d364d2f6be"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:37a138589b12069efb424220bf78eac59ca68b95696fc622b6ccc1c0a197204a"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:68a2dec79deebc5d26d617bfdf6e8aab065a4f34934b22d3b5010df3ba36612c"},
-    {file = "cryptography-41.0.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:09616eeaef406f99046553b8a40fbf8b1e70795a91885ba4c96a70793de5504a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:48a0476626da912a44cc078f9893f292f0b3e4c739caf289268168d8f4702a39"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c7f3201ec47d5207841402594f1d7950879ef890c0c495052fa62f58283fde1a"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c5ca78485a255e03c32b513f8c2bc39fedb7f5c5f8535545bdc223a03b24f248"},
-    {file = "cryptography-41.0.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d6c391c021ab1f7a82da5d8d0b3cee2f4b2c455ec86c8aebbc84837a631ff309"},
-    {file = "cryptography-41.0.7.tar.gz", hash = "sha256:13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc"},
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e"},
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7"},
+    {file = "cryptography-42.0.8-cp37-abi3-win32.whl", hash = "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2"},
+    {file = "cryptography-42.0.8-cp37-abi3-win_amd64.whl", hash = "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba"},
+    {file = "cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14"},
+    {file = "cryptography-42.0.8-cp39-abi3-win32.whl", hash = "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c"},
+    {file = "cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad"},
+    {file = "cryptography-42.0.8.tar.gz", hash = "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2"},
 ]
 
 [package.dependencies]
-cffi = ">=1.12"
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
 nox = ["nox"]
-pep8test = ["black", "check-sdist", "mypy", "ruff"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
 sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -1260,26 +1269,29 @@ files = [
 
 [[package]]
 name = "flwr"
-version = "1.7.0"
+version = "1.9.0"
 description = "Flower: A Friendly Federated Learning Framework"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "flwr-1.7.0-py3-none-any.whl", hash = "sha256:5240ab636c33bc94f7d9d46b7a24a6359a5588e2d9ae1c6defac7a0db2bc28eb"},
-    {file = "flwr-1.7.0.tar.gz", hash = "sha256:8c2c63068038fd7bd2f704079a7710195c500408d010d291662e6ca018936d21"},
+    {file = "flwr-1.9.0-py3-none-any.whl", hash = "sha256:a3f1b5a9bc56f7e53c3714919a2988bf73d0607c5eac1596b038123189a8e89a"},
+    {file = "flwr-1.9.0.tar.gz", hash = "sha256:99e869d29bcebe2fa585920cff4f059fb22585be59e3ffc2f017da4df82879a9"},
 ]
 
 [package.dependencies]
-cryptography = ">=41.0.2,<42.0.0"
+cryptography = ">=42.0.4,<43.0.0"
 grpcio = ">=1.60.0,<2.0.0"
 iterators = ">=0.0.2,<0.0.3"
 numpy = ">=1.21.0,<2.0.0"
+pathspec = ">=0.12.1,<0.13.0"
 protobuf = ">=4.25.2,<5.0.0"
 pycryptodome = ">=3.18.0,<4.0.0"
+tomli = ">=2.0.1,<3.0.0"
+typer = {version = ">=0.9.0,<0.10.0", extras = ["all"]}
 
 [package.extras]
 rest = ["requests (>=2.31.0,<3.0.0)", "starlette (>=0.31.0,<0.32.0)", "uvicorn[standard] (>=0.23.0,<0.24.0)"]
-simulation = ["pydantic (<2.0.0)", "ray (==2.6.3)"]
+simulation = ["ray (==2.10.0)"]
 
 [[package]]
 name = "fonttools"
@@ -5221,6 +5233,17 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments
 testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
 name = "simpleitk"
 version = "2.3.1"
 description = "SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation"
@@ -6090,6 +6113,30 @@ tests = ["autopep8", "flake8", "isort", "numpy", "pytest", "scipy (>=1.7.1)"]
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "typer"
+version = "0.9.4"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
+    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
+rich = {version = ">=10.11.0,<14.0.0", optional = true, markers = "extra == \"all\""}
+shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "types-docutils"
 version = "0.21.0.20240423"
 description = "Typing stubs for docutils"
@@ -6711,4 +6758,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.11"
-content-hash = "ff51dbf2bd4e488b85eb29caf74a23b335e872be6e594e9656be8deee0074f3c"
+content-hash = "c5a9f0d016036ee607f9bae77fe552fe18bba6ce7d44b5879ac359471e17a723"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 python = ">=3.9.0,<3.11"
 numpy = "^1.24"
 pandas = "^2.0"
-flwr = "1.7.0"
+flwr = "1.9.0"
 opacus = "^1.3.0"
 torch = "^2.1.1"
 pycyclops = "^0.2.5"

--- a/research/picai/picai_server.py
+++ b/research/picai/picai_server.py
@@ -1,7 +1,7 @@
 import timeit
 from logging import INFO
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch.nn as nn
 from flwr.common.logger import log
@@ -63,7 +63,7 @@ class PicaiServer(FlServerWithCheckpointing):
         )
         self.per_round_checkpointer = ServerPerRoundCheckpointer(intermediate_checkpoint_dir, Path("server.ckpt"))
 
-    def fit(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Overrides method in parent class to call custom fit_with_per_round_checkpointing that is resilient
         against pre-emptions.
@@ -73,15 +73,16 @@ class PicaiServer(FlServerWithCheckpointing):
             timeout (Optional[float]): The timeout for clients to return results in a given FL round.
 
         Returns:
-            History: The losses and metrics computed during training and validation.
+            Tuple[History, float]: The losses and metrics computed during training and validation
+                and the elapsed time in seconds.
         """
-        history = self.fit_with_per_epoch_checkpointing(num_rounds, timeout)
+        history, elapsed_time = self.fit_with_per_epoch_checkpointing(num_rounds, timeout)
         if self.wandb_reporter:
             # report history to W and B
             self.wandb_reporter.report_metrics(num_rounds, history)
-        return history
+        return history, elapsed_time
 
-    def fit_with_per_epoch_checkpointing(self, num_rounds: int, timeout: Optional[float]) -> History:
+    def fit_with_per_epoch_checkpointing(self, num_rounds: int, timeout: Optional[float]) -> Tuple[History, float]:
         """
         Runs federated learning for a number of rounds. Heavily based on the fit method from the base
         server provided by flower (flwr.server.server.Server) except that it is resilient to pre-emptions.
@@ -93,7 +94,8 @@ class PicaiServer(FlServerWithCheckpointing):
             timeout (Optional[float]): The timeout for clients to return results in a given FL round.
 
         Returns:
-            History: The losses and metrics computed during training and validation.
+            Tuple[History, float]: The losses and metrics computed during training and validation and
+                the elapsed time in seconds.
         """
         # Initialize parameters
         log(INFO, "Initializing global parameters")
@@ -103,7 +105,7 @@ class PicaiServer(FlServerWithCheckpointing):
             model, history, server_round = self.per_round_checkpointer.load_checkpoint()
             self.parameters = get_initial_model_parameters(model)
         else:
-            self.parameters = self._get_initial_parameters(timeout)
+            self.parameters = self._get_initial_parameters(server_round=1, timeout=timeout)
             history = History()
             server_round = 1
 
@@ -165,6 +167,6 @@ class PicaiServer(FlServerWithCheckpointing):
 
         # Bookkeeping
         end_time = timeit.default_timer()
-        elapsed = end_time - start_time
-        log(INFO, "FL finished in %s", elapsed)
-        return history
+        elapsed_time = end_time - start_time
+        log(INFO, "FL finished in %s", elapsed_time)
+        return history, elapsed_time

--- a/research/picai/picai_server.py
+++ b/research/picai/picai_server.py
@@ -73,8 +73,9 @@ class PicaiServer(FlServerWithCheckpointing):
             timeout (Optional[float]): The timeout for clients to return results in a given FL round.
 
         Returns:
-            Tuple[History, float]: The losses and metrics computed during training and validation
-                and the elapsed time in seconds.
+            Tuple[History, float]: The first element of the tuple is a history object containing the losses and
+                metrics computed during training and validation. The second element of the tuple is
+                the elapsed time in seconds.
         """
         history, elapsed_time = self.fit_with_per_epoch_checkpointing(num_rounds, timeout)
         if self.wandb_reporter:
@@ -94,7 +95,8 @@ class PicaiServer(FlServerWithCheckpointing):
             timeout (Optional[float]): The timeout for clients to return results in a given FL round.
 
         Returns:
-            Tuple[History, float]: The losses and metrics computed during training and validation and
+            Tuple[History, float]: The first element of the tuple is a history object containing the losses and
+                metrics computed during training and validation. The second element of the tuple is
                 the elapsed time in seconds.
         """
         # Initialize parameters

--- a/tests/server/test_base_server.py
+++ b/tests/server/test_base_server.py
@@ -98,7 +98,7 @@ def test_metrics_reporter_fit(mock_fit: Mock) -> None:
     test_history = History()
     test_history.metrics_centralized = {"test metrics centralized": [(123, "loss")]}
     test_history.losses_centralized = [(123, 123.123)]
-    mock_fit.return_value = test_history
+    mock_fit.return_value = (test_history, 1)
 
     fl_server = FlServer(SimpleClientManager())
     fl_server.fit(3, None)

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -226,33 +226,20 @@ async def run_smoke_test(
     assert "error" not in full_server_output.lower(), (
         f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] Error message found for server."
     )
-    if assert_evaluation_logs:
-        assert f"Federated Evaluation received {config['n_clients']} results and 0 failures" in full_server_output, (
-            f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] Last FL round message not found for server."
-        )
-        assert "Federated Evaluation Finished" in full_server_output, (
-            f"Full output:\n{full_server_output}\n"
-            "[ASSERT ERROR] Federated Evaluation Finished message not found for server."
-        )
-    else:
-        assert f"evaluate_round {config['n_server_rounds']}" in full_server_output, (
-            f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] Last FL round message not found for server."
-        )
-        assert "[SUMMARY]" in full_server_output, (
-            f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
-        )
-    """
+    assert "[SUMMARY]" in full_server_output, (
+        f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
+    )
+
     assert all(
         message in full_server_output
         for message in [
-            "app_fit: losses_distributed",
-            "app_fit: metrics_distributed_fit",
-            "app_fit: metrics_distributed",
-            "app_fit: losses_centralized",
-            "app_fit: metrics_centralized",
+            "configure_fit: strategy",
+            "aggregate_fit: received",
+            "[ROUND 1]",
+            "[ROUND 2]",
+            "[ROUND 3]",
         ]
     ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
-    """
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -267,12 +254,7 @@ async def run_smoke_test(
             f"Full client output:\n{full_client_outputs[i]}\n"
             f"[ASSERT ERROR] Shutdown message not found for client {i}."
         )
-        if assert_evaluation_logs:
-            assert "Client Evaluation Local Model Metrics" in full_client_outputs[i], (
-                f"Full client output:\n{full_client_outputs[i]}\n"
-                f"[ASSERT ERROR] 'Client Evaluation Local Model Metrics' message not found for client {i}."
-            )
-        elif not skip_assert_client_fl_rounds:
+        if not skip_assert_client_fl_rounds:
             assert f"Current FL Round: {config['n_server_rounds']}" in full_client_outputs[i], (
                 f"Full client output:\n{full_client_outputs[i]}\n"
                 f"[ASSERT ERROR] Last FL round message not found for client {i}."

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -241,9 +241,9 @@ async def run_smoke_test(
     assert all(
         message in full_server_output
         for message in [
-            "round1:",
-            "round2:",
-            "round3:",
+            "round 1:",
+            "round 2:",
+            "round 3:",
             "History (loss, distributed):",
             "History (metrics, distributed, fit):",
         ]

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -238,18 +238,10 @@ async def run_smoke_test(
         assert "[SUMMARY]" in full_server_output, (
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
-    """
+    print(full_server_output)
     assert all(
-        message in full_server_output
-        for message in [
-            "app_fit: losses_distributed",
-            "app_fit: metrics_distributed_fit",
-            "app_fit: metrics_distributed",
-            "app_fit: losses_centralized",
-            "app_fit: metrics_centralized",
-        ]
+        message in full_server_output for message in ["[ROUND 1]"]
     ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
-    """
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -241,6 +241,7 @@ async def run_smoke_test(
         assert "[SUMMARY]" in full_server_output, (
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
+    """
     assert all(
         message in full_server_output
         for message in [
@@ -251,6 +252,7 @@ async def run_smoke_test(
             "app_fit: metrics_centralized",
         ]
     ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
+    """
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -239,7 +239,14 @@ async def run_smoke_test(
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
     assert all(
-        message in full_server_output for message in ["[ROUND 1]", "[ROUND 2]", "[ROUND 3]"]
+        message in full_server_output
+        for message in [
+            "round1:",
+            "round2:",
+            "round3:",
+            "History (loss, distributed):",
+            "History (metrics, distributed, fit):",
+        ]
     ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -241,9 +241,6 @@ async def run_smoke_test(
     assert all(
         message in full_server_output
         for message in [
-            "round 1:",
-            "round 2:",
-            "round 3:",
             "History (loss, distributed):",
             "History (metrics, distributed, fit):",
         ]

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -160,6 +160,7 @@ async def run_smoke_test(
         "Polling Clients for sample counts",
         # printed by federated_eval
         "Federated Evaluation Starting",
+        "[ROUND 1]",
     ]
 
     output_found = False

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -238,9 +238,8 @@ async def run_smoke_test(
         assert "[SUMMARY]" in full_server_output, (
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
-    print(full_server_output)
     assert all(
-        message in full_server_output for message in ["[ROUND 1]"]
+        message in full_server_output for message in ["[ROUND 1]", "[ROUND 2]", "[ROUND 3]"]
     ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -238,13 +238,18 @@ async def run_smoke_test(
         assert "[SUMMARY]" in full_server_output, (
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
-    assert all(
-        message in full_server_output
-        for message in [
-            "History (loss, distributed):",
-            "History (metrics, distributed, fit):",
-        ]
-    ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
+    if not assert_evaluation_logs:
+        assert all(
+            message in full_server_output
+            for message in [
+                "History (loss, distributed):",
+                "History (metrics, distributed, fit):",
+            ]
+        ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
+    else:
+        assert all(
+            message in full_server_output for message in ["History (metrics, distributed, evaluate):"]
+        ), f"Full output:\n{full_server_output}\n[ASSERT ERROR] Metrics message not found for server."
 
     server_errors = _assert_metrics(MetricType.SERVER, server_metrics)
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -238,8 +238,8 @@ async def run_smoke_test(
         assert f"evaluate_round {config['n_server_rounds']}" in full_server_output, (
             f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] Last FL round message not found for server."
         )
-        assert "FL finished" in full_server_output, (
-            f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] FL finished message not found for server."
+        assert "[SUMMARY]" in full_server_output, (
+            f"Full output:\n{full_server_output}\n" "[ASSERT ERROR] [SUMMARY] message not found for server."
         )
     assert all(
         message in full_server_output

--- a/tests/test_utils/custom_client_proxy.py
+++ b/tests/test_utils/custom_client_proxy.py
@@ -28,6 +28,7 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: GetPropertiesIns,
         timeout: Optional[float],
+        group_id: Optional[int],
     ) -> GetPropertiesRes:
         status: Status = Status(code=Code["OK"], message="Test")
         res = GetPropertiesRes(status=status, properties=self.properties)
@@ -37,6 +38,7 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: GetParametersIns,
         timeout: Optional[float],
+        group_id: Optional[int],
     ) -> GetParametersRes:
         raise NotImplementedError
 
@@ -44,6 +46,7 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: FitIns,
         timeout: Optional[float],
+        group_id: Optional[int],
     ) -> FitRes:
         raise NotImplementedError
 
@@ -51,6 +54,7 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: EvaluateIns,
         timeout: Optional[float],
+        group_id: Optional[int],
     ) -> EvaluateRes:
         raise NotImplementedError
 
@@ -58,5 +62,6 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: ReconnectIns,
         timeout: Optional[float],
+        group_id: Optional[int],
     ) -> DisconnectRes:
         raise NotImplementedError

--- a/tests/test_utils/custom_client_proxy.py
+++ b/tests/test_utils/custom_client_proxy.py
@@ -28,7 +28,6 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: GetPropertiesIns,
         timeout: Optional[float],
-        group_id: Optional[int],
     ) -> GetPropertiesRes:
         status: Status = Status(code=Code["OK"], message="Test")
         res = GetPropertiesRes(status=status, properties=self.properties)
@@ -38,7 +37,6 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: GetParametersIns,
         timeout: Optional[float],
-        group_id: Optional[int],
     ) -> GetParametersRes:
         raise NotImplementedError
 
@@ -46,7 +44,6 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: FitIns,
         timeout: Optional[float],
-        group_id: Optional[int],
     ) -> FitRes:
         raise NotImplementedError
 
@@ -54,7 +51,6 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: EvaluateIns,
         timeout: Optional[float],
-        group_id: Optional[int],
     ) -> EvaluateRes:
         raise NotImplementedError
 
@@ -62,6 +58,5 @@ class CustomClientProxy(ClientProxy):
         self,
         ins: ReconnectIns,
         timeout: Optional[float],
-        group_id: Optional[int],
     ) -> DisconnectRes:
         raise NotImplementedError


### PR DESCRIPTION
# PR Type
[Feature | Fix | Documentation | **Other** ]

# Short Description

Clickup Ticket(s): [Upgrade Core Dependencies (flwr)](https://app.clickup.com/t/8688zkaey)

Short PR to upgrade Flower from 1.7 to 1.9. There was some small changes to the server including: 
- get_initial_parameters now takes an int as its first argument (server round)
- fit methods now return elapsed time along with history 
- the addition of the group_id parameter in evaluate clients which is set to server round when available following flwr

flwr also changed the logging format so I had to update the smoke tests. Lastly, in the upgrade to 1.9, flwr upgraded cryptography to a version that no longer fails pip audit so I removed the corresponding vulnerabilities from ignore.

# Tests Added

NA
