### PR TITLE
added epoch hook

### DIFF
--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -606,6 +606,9 @@ class BasicClient(NumPyClient):
             self._handle_logging(loss_dict, metrics, current_round=current_round, current_epoch=local_epoch)
             self._handle_reporting(loss_dict, metrics, current_round=current_round)
 
+            # update after epoch hook
+            self.update_after_epoch(epoch=local_epoch)
+
         # Return final training metrics
         return loss_dict, metrics
 
@@ -1052,5 +1055,15 @@ class BasicClient(NumPyClient):
 
         Args:
             step (int): The step number in local training that was most recently completed.
+        """
+        pass
+
+    def update_after_epoch(self, epoch: int) -> None:
+        """
+        Hook method called after local epoch on client. Only called if client is
+        being trained by epochs (ie. using local_epochs key instead of local steps in the server config file)
+
+        Args:
+            epoch (int): Integer representing the most recently completed epoch
         """
         pass


### PR DESCRIPTION
# PR Type
[**Feature** | Fix | Documentation | Other ]

# Short Description

Added a hook 'update_after_epoch'. Added this mainly to allow users to use lr_schedulers and call scheduler.step() in this method. The reason I created a hook rather than a self.lr_scheduler attribute is that the epoch argument for the pytorch step method is about to be deprecated. So we can leave it up to the user how the lr_scheduler step is called. Additionally this allows the user to add a log with the current LR as well. The log could have been added to the _handle_logging method, but for the nnunet lr_scheduler at least, they overrode the step function and don't update the self._last_lr attribute so the only way to get the LR would be to get it from the optimizer state_dict, but that felt messy. Hence my decision to just add a hook and let the user do whatever they want. I didn't actually test the method because its a very simple change and I didn't feel it warranted writing an entire FL experiment set up just to test that the hook works
