### PR TITLE
Added epoch hook for lr scheduling and made client logs look better

### DIFF
--- a/fl4health/utils/typing.py
+++ b/fl4health/utils/typing.py
@@ -1,3 +1,5 @@
+import logging
+from enum import Enum
 from typing import Callable, Dict, Tuple, Union
 
 import torch
@@ -7,3 +9,12 @@ TorchTargetType = Union[torch.Tensor, Dict[str, torch.Tensor]]
 TorchPredType = Dict[str, torch.Tensor]
 TorchFeatureType = Dict[str, torch.Tensor]
 TorchTransformType = Callable[[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]
+
+
+class LogLevel(Enum):
+    NOTSET = logging.NOTSET
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -4,6 +4,6 @@ nnunet_config: 2d
 nnunet_plans: /home/shawn/Code/nnunet_storage/nnUNet_preprocessed/Dataset012_PICAI-debug/nnUNetPlans.json
 fold: 0
 n_server_rounds: 1
-local_epochs: 1
+local_epochs: 10
 server_address: '0.0.0.0:8080'
 starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset012_PICAI-debug/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -4,6 +4,6 @@ nnunet_config: 2d
 nnunet_plans: /home/shawn/Code/nnunet_storage/nnUNet_preprocessed/Dataset012_PICAI-debug/nnUNetPlans.json
 fold: 0
 n_server_rounds: 1
-local_epochs: 10
+local_epochs: 3
 server_address: '0.0.0.0:8080'
 starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset012_PICAI-debug/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth

--- a/research/picai/fl_nnunet/nnunet_client.py
+++ b/research/picai/fl_nnunet/nnunet_client.py
@@ -513,3 +513,8 @@ class nnUNetClient(BasicClient):
             torch.mps.empty_cache()
         else:
             pass
+
+    def update_before_epoch(self, epoch: int) -> None:
+        self.nnunet_trainer.lr_scheduler.step(epoch)
+        lr = self.optimizers["global"].param_groups[0]["lr"]
+        self.add_to_initial_log_str += f" Current LR: {lr}"

--- a/research/picai/fl_nnunet/nnunet_client.py
+++ b/research/picai/fl_nnunet/nnunet_client.py
@@ -21,7 +21,7 @@ from fl4health.clients.basic_client import BasicClient
 from fl4health.reporting.metrics import MetricsReporter
 from fl4health.utils.losses import LossMeterType
 from fl4health.utils.metrics import Metric, MetricManager
-from fl4health.utils.typing import TorchInputType, TorchPredType, TorchTargetType
+from fl4health.utils.typing import LogLevel, TorchInputType, TorchPredType, TorchTargetType
 from research.picai.fl_nnunet.nnunet_utils import (
     Module2LossWrapper,
     NnUNetConfig,
@@ -515,6 +515,9 @@ class nnUNetClient(BasicClient):
             pass
 
     def update_before_epoch(self, epoch: int) -> None:
+        # Update the learning rate
         self.nnunet_trainer.lr_scheduler.step(epoch)
+
+    def get_client_specific_logs(self) -> Tuple[str, List[Tuple[LogLevel, str]]]:
         lr = self.optimizers["global"].param_groups[0]["lr"]
-        self.add_to_initial_log_str += f" Current LR: {lr}"
+        return f" Current LR: {lr}", []


### PR DESCRIPTION
# PR Type
[**Feature** | Fix | Documentation | Other ]

# Short Description

- Added an update_before_epoch hook method to BasicClient
- Used update_before_epoch to enable lr scheduling in nnUNetClient
- Added the add_to_initial_log_str attribute to Basic Client to allow users to add information to the initial log string (such as current LR)
- Reformatted logging in _handle_logging method of BasicClient to make things more readable

Note: The add_to_initial_log_str seemed like the cleanest solution to me to allow users to add info to the inital log string. I made sure to add a comment in the BasicClient init where the attribute is defined to explain how it works. Although it is a functionality that could be easily overlooked if users don't look through the BasicClient code. 

Additionally, one thing i did notice is that by introducing this attribute to basic client, you can actually remove the current_epoch argument of _handle_logging and instead just do ```self.add_to_initial_log_str += f' Current Epoch: {local_epoch}'``` in train_by_epochs. Curious to get your opinion on whether or not I should make this change, however i didn't for now since it might affect other clients

Here is a screenshot of how the logs look now:

![Screenshot from 2024-07-22 12-46-55](https://github.com/user-attachments/assets/9c7bd238-be08-42a8-ab7f-aa01255454dd)


