### PR TITLE
Changed nnunet LR Schedule and fixed memory leak

### DIFF
--- a/fl4health/clients/apfl_client.py
+++ b/fl4health/clients/apfl_client.py
@@ -32,7 +32,7 @@ class ApflClient(BasicClient):
     def is_start_of_local_training(self, step: int) -> bool:
         return step == 0
 
-    def update_after_step(self, step: int) -> None:
+    def update_after_step(self, step: int, current_round: Optional[int] = None) -> None:
         """
         Called after local train step on client. step is an integer that represents
         the local training step that was most recently completed.

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -608,6 +608,7 @@ class BasicClient(NumPyClient):
 
         # Compute backward pass and update parameters with optimizer
         losses.backward["backward"].backward()
+        self.transform_gradients(losses)
         self.optimizers["global"].step()
 
         return losses, preds
@@ -1192,3 +1193,14 @@ class BasicClient(NumPyClient):
                 "bar_format": f"{LOG_COLORS['INFO']}INFO{LOG_COLORS['RESET']}" + " :        {l_bar}{bar}{r_bar}",
             }
             return tqdm(iterable, **kwargs)
+
+    def transform_gradients(self, losses: TrainingLosses) -> None:
+        """
+        Hook function for model training only called after backwards pass but before
+        optimizer step. Useful for transforming the gradients (such as with gradient
+        clipping) before they are applied to the model weights.
+
+        Args:
+            losses (TrainingLosses): The losses object from the train step
+        """
+        pass

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -266,7 +266,7 @@ class BasicClient(NumPyClient):
             raise ValueError("Must specify either local_epochs or local_steps in the Config.")
 
         # Update after train round (Used by Scaffold and DP-Scaffold Client to update control variates)
-        self.update_after_train(local_steps, loss_dict)
+        self.update_after_train(local_steps, loss_dict, config)
 
         # Check if we should run an evaluation with validation data after fit
         # (for example, this is used by FedDGGA)
@@ -1115,7 +1115,7 @@ class BasicClient(NumPyClient):
         """
         pass
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         Hook method called after training with the number of local_steps performed over the FL round and
         the corresponding loss dictionary. For example, used by Scaffold to update the control variates
@@ -1127,6 +1127,7 @@ class BasicClient(NumPyClient):
             local_steps (int): The number of steps so far in the round in the local
                 training.
             loss_dict (Dict[str, float]): A dictionary of losses from local training.
+            config (Config): The config from the server
         """
         pass
 

--- a/fl4health/clients/constrained_fenda_client.py
+++ b/fl4health/clients/constrained_fenda_client.py
@@ -126,7 +126,7 @@ class ConstrainedFendaClient(FendaClient):
 
         return preds, features
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         This function is called after client-side training concludes. If a contrastive or PerFCL loss function has
         been defined, it is used to save the local and global feature extraction weights/modules to be used in the
@@ -143,7 +143,7 @@ class ConstrainedFendaClient(FendaClient):
             self.old_local_module = self.clone_and_freeze_model(self.model.first_feature_extractor)
             self.old_global_module = self.clone_and_freeze_model(self.model.second_feature_extractor)
 
-        super().update_after_train(local_steps, loss_dict)
+        super().update_after_train(local_steps, loss_dict, config)
 
     def update_before_train(self, current_server_round: int) -> None:
         """

--- a/fl4health/clients/fed_prox_client.py
+++ b/fl4health/clients/fed_prox_client.py
@@ -136,7 +136,7 @@ class FedProxClient(BasicClient):
     def get_parameter_exchanger(self, config: Config) -> ParameterExchanger:
         return ParameterExchangerWithPacking(ParameterPackerFedProx())
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         Called after training with the number of local_steps performed over the FL round and
         the corresponding loss dictionary.

--- a/fl4health/clients/flash_client.py
+++ b/fl4health/clients/flash_client.py
@@ -76,7 +76,7 @@ class FlashClient(BasicClient):
                 losses, preds = self.train_step(input, target)
                 self.train_loss_meter.update(losses)
                 self.train_metric_manager.update(preds, target)
-                self.update_after_step(local_step)
+                self.update_after_step(local_step, current_round)
                 self.total_steps += 1
                 local_step += 1
 

--- a/fl4health/clients/moon_client.py
+++ b/fl4health/clients/moon_client.py
@@ -6,7 +6,7 @@ import torch
 from flwr.common.logger import log
 
 from fl4health.checkpointing.client_module import ClientCheckpointModule
-from fl4health.clients.basic_client import BasicClient
+from fl4health.clients.basic_client import BasicClient, Config
 from fl4health.losses.contrastive_loss import MoonContrastiveLoss
 from fl4health.model_bases.sequential_split_models import SequentiallySplitModel
 from fl4health.utils.losses import EvaluationLosses, LossMeterType, TrainingLosses
@@ -100,7 +100,7 @@ class MoonClient(BasicClient):
             features.update({"global_features": global_model_features["features"]})
         return preds, features
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         This function is called immediately after client-side training has completed. This function saves the final
         trained model to the list of old models to be used in subsequent server rounds
@@ -108,6 +108,7 @@ class MoonClient(BasicClient):
         Args:
             local_steps (int): Number of local steps performed during training
             loss_dict (Dict[str, float]): Loss dictionary associated with training.
+            config (Config): The config from the server
         """
         assert isinstance(self.model, SequentiallySplitModel)
         # Save the parameters of the old LOCAL model
@@ -118,7 +119,7 @@ class MoonClient(BasicClient):
         if len(self.old_models_list) > self.len_old_models_buffer:
             self.old_models_list.pop(0)
 
-        super().update_after_train(local_steps, loss_dict)
+        super().update_after_train(local_steps, loss_dict, config)
 
     def update_before_train(self, current_server_round: int) -> None:
         """

--- a/fl4health/clients/perfcl_client.py
+++ b/fl4health/clients/perfcl_client.py
@@ -148,7 +148,7 @@ class PerFclClient(BasicClient):
 
         return preds, features
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         This function is called after client-side training concludes. In this case, it is used to save the local
         and global feature extraction weights/modules to be used in the next round of client-side training.
@@ -156,6 +156,7 @@ class PerFclClient(BasicClient):
         Args:
             local_steps (int): Number of steps performed during training
             loss_dict (Dict[str, float]): Losses computed during training.
+            config (Config): The config from the server
         """
         assert isinstance(self.model, PerFclModel)
         # First module is the local feature extractor for PerFcl Models
@@ -163,7 +164,7 @@ class PerFclClient(BasicClient):
         # Second module is the global feature extractor for PerFcl Models
         self.old_global_module = self.clone_and_freeze_model(self.model.second_feature_extractor)
 
-        super().update_after_train(local_steps, loss_dict)
+        super().update_after_train(local_steps, loss_dict, config)
 
     def update_before_train(self, current_server_round: int) -> None:
         """

--- a/fl4health/clients/scaffold_client.py
+++ b/fl4health/clients/scaffold_client.py
@@ -222,7 +222,7 @@ class ScaffoldClient(BasicClient):
         parameter_exchanger = ParameterExchangerWithPacking(ParameterPackerWithControlVariates(model_size))
         return parameter_exchanger
 
-    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float]) -> None:
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
         """
         Called after training with the number of local_steps performed over the FL round and
         the corresponding loss dictionary.

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -1,6 +1,6 @@
 # FL4Health Settings:
 n_clients: 1
-n_server_rounds: 10
+n_server_rounds: 4
 server_address: '0.0.0.0:8080'
 local_epochs: 2
 # local_steps: 2

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -1,9 +1,9 @@
 # FL4Health Settings:
 n_clients: 1
-n_server_rounds: 1
+n_server_rounds: 2
 server_address: '0.0.0.0:8080'
-local_epochs: 3
-# local_steps: 50
+# local_epochs: 3
+local_steps: 20
 # starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset004_Hippocampus/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth
 
 # nnunet Settings:

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -1,9 +1,9 @@
 # FL4Health Settings:
 n_clients: 1
-n_server_rounds: 2
+n_server_rounds: 20
 server_address: '0.0.0.0:8080'
 # local_epochs: 3
-local_steps: 20
+local_steps: 2
 # starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset004_Hippocampus/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth
 
 # nnunet Settings:

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -1,9 +1,9 @@
 # FL4Health Settings:
 n_clients: 1
-n_server_rounds: 20
+n_server_rounds: 10
 server_address: '0.0.0.0:8080'
-# local_epochs: 3
-local_steps: 2
+local_epochs: 2
+# local_steps: 2
 # starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset004_Hippocampus/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth
 
 # nnunet Settings:

--- a/research/picai/fl_nnunet/config.yaml
+++ b/research/picai/fl_nnunet/config.yaml
@@ -1,9 +1,9 @@
 # FL4Health Settings:
 n_clients: 1
-n_server_rounds: 4
+n_server_rounds: 20
 server_address: '0.0.0.0:8080'
-local_epochs: 2
-# local_steps: 2
+# local_epochs: 1
+local_steps: 20
 # starting_checkpoint: /home/shawn/Code/nnunet_storage/nnUNet_results/Dataset004_Hippocampus/nnUNetTrainer_1epoch__nnUNetPlans__2d/fold_0/checkpoint_best.pth
 
 # nnunet Settings:

--- a/research/picai/fl_nnunet/nnunet_client.py
+++ b/research/picai/fl_nnunet/nnunet_client.py
@@ -23,7 +23,7 @@ from fl4health.checkpointing.client_module import ClientCheckpointModule
 from fl4health.clients.basic_client import BasicClient, LoggingMode
 from fl4health.reporting.metrics import MetricsReporter
 from fl4health.utils.config import narrow_config_type
-from fl4health.utils.losses import LossMeterType
+from fl4health.utils.losses import LossMeterType, TrainingLosses
 from fl4health.utils.metrics import Metric, MetricManager
 from fl4health.utils.typing import LogLevel, TorchInputType, TorchPredType, TorchTargetType
 from research.picai.fl_nnunet.nnunet_utils import (
@@ -704,3 +704,10 @@ class nnUNetClient(BasicClient):
             # If we freeze before the first pass, gc.collect has to check all those
             # variables
             gc.freeze()
+
+    def transform_gradients(self, losses: TrainingLosses) -> None:
+        """
+        Apply the gradient clipping performed by the default nnunet trainer. This is
+        the default behaviour for nnunet 2.5.1
+        """
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 12)

--- a/research/picai/fl_nnunet/nnunet_client.py
+++ b/research/picai/fl_nnunet/nnunet_client.py
@@ -758,3 +758,10 @@ class nnUNetClient(BasicClient):
         the default behaviour for nnunet 2.5.1
         """
         torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
+
+    def update_after_train(self, local_steps: int, loss_dict: Dict[str, float], config: Config) -> None:
+        current_server_round = narrow_config_type(config, "current_server_round", int)
+        n_server_rounds = narrow_config_type(config, "n_server_rounds", int)
+        if current_server_round == n_server_rounds:
+            gc.unfreeze()
+            gc.collect()

--- a/research/picai/fl_nnunet/nnunet_client.py
+++ b/research/picai/fl_nnunet/nnunet_client.py
@@ -267,9 +267,11 @@ class nnUNetClient(BasicClient):
         # Get the nnunet plans specified by the server
         plans = pickle.loads(narrow_config_type(config, "nnunet_plans", bytes))
 
-        # Change plans name
+        # Change plans name.
         if self.plans_name is None:
-            self.plans_name = f"FL_Dataset{self.dataset_id:03d}" + "-" + plans["plans_name"]
+            self.plans_name = "FL_source-" + plans["plans_name"]
+
+        plans["source_plans_name"] = plans["plans_name"]
         plans["plans_name"] = self.plans_name
 
         # Change dataset name
@@ -678,9 +680,9 @@ class nnUNetClient(BasicClient):
         with contextlib.redirect_stdout(None):  # Prevent print statements from experiment planner
             plans = planner.plan_experiment()
 
-        # Set plans name to default nnunet plans name. FL related stuff will be
-        # appended in setup_client so that it doesn't overwrite existing default
-        plans["plans_name"] = "nnUNetPlans"
+        # Set plans name to local dataset so we know the source
+        # Dataset name normally begins with Dataset123_, we remove it and keep suffix
+        plans["plans_name"] = self.dataset_name[11:] + "_plans"
         plans_bytes = pickle.dumps(plans)
 
         # Remove plans file . A new one will be generated in self.setup_client

--- a/research/picai/fl_nnunet/nnunet_utils.py
+++ b/research/picai/fl_nnunet/nnunet_utils.py
@@ -99,7 +99,7 @@ def convert_deepsupervision_dict_to_list(tensor_dict: Dict[str, torch.Tensor]) -
 class nnUNetDataLoaderWrapper(DataLoader):
     def __init__(
         self,
-        nnunet_augmenter: Union[SingleThreadedAugmenter, NonDetMultiThreadedAugmenter],
+        nnunet_augmenter: Union[SingleThreadedAugmenter, NonDetMultiThreadedAugmenter, MultiThreadedAugmenter],
         nnunet_config: NnUNetConfig,
         infinite: bool = False,
     ) -> None:
@@ -119,6 +119,7 @@ class nnUNetDataLoaderWrapper(DataLoader):
                 StopIteration is generated after num_samples/batch_size steps.
                 Defaults to False.
         """
+        # The augmenter is a wrapper on the nnunet dataloader
         self.nnunet_augmenter = nnunet_augmenter
 
         if isinstance(self.nnunet_augmenter, SingleThreadedAugmenter):

--- a/research/picai/fl_nnunet/nnunet_utils.py
+++ b/research/picai/fl_nnunet/nnunet_utils.py
@@ -15,6 +15,7 @@ with warnings.catch_warnings():
     # silences a bunch of deprecation warnings related to scipy.ndimage
     # Raised an issue with nnunet. https://github.com/MIC-DKFZ/nnUNet/issues/2370
     warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from batchgenerators.dataloading.multi_threaded_augmenter import MultiThreadedAugmenter
     from batchgenerators.dataloading.nondet_multi_threaded_augmenter import NonDetMultiThreadedAugmenter
     from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
     from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
@@ -178,6 +179,12 @@ class nnUNetDataLoaderWrapper(DataLoader):
     def __iter__(self) -> DataLoader:  # type: ignore
         # mypy gets angry that the return type is different
         return self
+
+    def shutdown(self) -> None:
+        if isinstance(self.nnunet_augmenter, (NonDetMultiThreadedAugmenter, MultiThreadedAugmenter)):
+            self.nnunet_augmenter._finish()
+        else:
+            del self.nnunet_augmenter
 
 
 class Module2LossWrapper(_Loss):

--- a/research/picai/fl_nnunet/start_client.py
+++ b/research/picai/fl_nnunet/start_client.py
@@ -69,7 +69,7 @@ def main(
         # BaseClient Args
         device=DEVICE,
         metrics=metrics,
-        progress_bar=True,
+        progress_bar=False,
         data_path=Path("dummy/path"),  # Argument not used by nnUNetClient
     )
 

--- a/research/picai/picai_client.py
+++ b/research/picai/picai_client.py
@@ -84,7 +84,7 @@ class PicaiClient(BasicClient):
             raise ValueError("Must specify either local_epochs or local_steps in the Config.")
 
         # Update after train round (Used by Scaffold and DP-Scaffold Client to update control variates)
-        self.update_after_train(local_steps, loss_dict)
+        self.update_after_train(local_steps, loss_dict, config)
 
         # After local client training has finished, checkpoint model, optimizer and client name
         self.per_round_checkpointer.save_checkpoint(

--- a/tests/clients/test_constrained_fenda_client.py
+++ b/tests/clients/test_constrained_fenda_client.py
@@ -34,7 +34,7 @@ def test_getting_parameters(get_constrained_fenda_client: ConstrainedFendaClient
     }
     # Do an update after training. This should be setting the required old models for the contrastive loss
     # calculations in the next round.
-    const_fenda_client.update_after_train(0, loss)
+    const_fenda_client.update_after_train(0, loss, config)
 
     # Get parameters that we send to the server for aggregation. Should be the params_global values.
     global_params_for_server = const_fenda_client.get_parameters(config)
@@ -188,7 +188,7 @@ def test_setting_old_models(get_constrained_fenda_client: ConstrainedFendaClient
     loss = {
         "loss": 0.0,
     }
-    const_fenda_client.update_after_train(0, loss)
+    const_fenda_client.update_after_train(0, loss, {})
 
     assert const_fenda_client.old_local_module is not None
     old_local_params = [
@@ -239,7 +239,7 @@ def test_setting_not_setting_old_models(get_constrained_fenda_client: Constraine
     loss = {
         "loss": 0.0,
     }
-    const_fenda_client.update_after_train(0, loss)
+    const_fenda_client.update_after_train(0, loss, {})
 
     # Make sure they are still None
     assert const_fenda_client.old_local_module is None

--- a/tests/clients/test_moon_client.py
+++ b/tests/clients/test_moon_client.py
@@ -73,7 +73,7 @@ def test_setting_old_models(get_client: MoonClient) -> None:  # noqa
     loss = {
         "loss": 0.0,
     }
-    moon_client.update_after_train(0, loss)
+    moon_client.update_after_train(0, loss, {})
 
     # Assert we stored the old model
     assert len(moon_client.old_models_list) == 1
@@ -110,7 +110,7 @@ def test_getting_parameters(get_client: MoonClient) -> None:  # noqa
     loss = {
         "loss": 0.0,
     }
-    moon_client.update_after_train(0, loss)
+    moon_client.update_after_train(0, loss, config)
     # Mocking sending parameters to the server, need to make sure the old_model_list is updated
     _ = moon_client.get_parameters(config)
     new_params = [layer_weights + 0.1 for layer_weights in params]
@@ -137,7 +137,7 @@ def test_getting_parameters(get_client: MoonClient) -> None:  # noqa
     # Do another round to make sure old model list doesn't expand and it contains new parameters
     # Mocking sending parameters to the server, need to make sure the old_model_list is updated
     config["current_server_round"] = 2
-    moon_client.update_after_train(0, loss)
+    moon_client.update_after_train(0, loss, config)
     _ = moon_client.get_parameters(config)
     new_params_2 = [layer_weights + 0.1 for layer_weights in params]
     # Setting parameters once to represent an evaluation set parameters
@@ -280,8 +280,8 @@ def test_popping_old_models_when_queue_fills(get_client: MoonClient) -> None:  #
     original_base_module_params = [copy.deepcopy(val.cpu().numpy()) for val in moon_client.model.state_dict().values()]
     assert len(original_base_module_params) > 0
 
-    moon_client.update_after_train(0, {})
-    moon_client.update_after_train(1, {})
+    moon_client.update_after_train(0, {}, {})
+    moon_client.update_after_train(1, {}, {})
     assert len(moon_client.old_models_list) == 2
 
     # Now we do a little "training," updating the model weights
@@ -291,7 +291,7 @@ def test_popping_old_models_when_queue_fills(get_client: MoonClient) -> None:  #
     new_base_module_params = [copy.deepcopy(val.cpu().numpy()) for val in moon_client.model.state_dict().values()]
     assert len(new_base_module_params) > 0
 
-    moon_client.update_after_train(2, {})
+    moon_client.update_after_train(2, {}, {})
     assert len(moon_client.old_models_list) == 2
 
     # The first "old model" should have the original model parameters.

--- a/tests/clients/test_perfcl_client.py
+++ b/tests/clients/test_perfcl_client.py
@@ -32,7 +32,7 @@ def test_getting_parameters(get_perfcl_client: PerFclClient) -> None:  # noqa
     }
     # Do an update after training. This should be setting the required old models for the contrastive loss
     # calculations in the next round.
-    perfcl_client.update_after_train(0, loss)
+    perfcl_client.update_after_train(0, loss, config)
 
     # Get parameters that we send to the server for aggregation. Should be the params_global values.
     global_params_for_server = perfcl_client.get_parameters(config)
@@ -161,7 +161,7 @@ def test_setting_old_models(get_perfcl_client: PerFclClient) -> None:  # noqa
     loss = {
         "loss": 0.0,
     }
-    perfcl_client.update_after_train(0, loss)
+    perfcl_client.update_after_train(0, loss, {})
 
     assert perfcl_client.old_local_module is not None
     old_local_params = [
@@ -229,7 +229,7 @@ def test_computing_loss(get_perfcl_client: PerFclClient) -> None:  # noqa
 
     # Now we mock having "set" the right components. So we should compute the full set of loss components
     perfcl_client.update_before_train(0)
-    perfcl_client.update_after_train(0, {})
+    perfcl_client.update_after_train(0, {}, {})
 
     training_loss = perfcl_client.compute_training_loss(preds=preds, target=target, features=features)
     evaluation_loss = perfcl_client.compute_evaluation_loss(preds=preds, target=target, features=features)


### PR DESCRIPTION
# PR Type
[Feature | **Fix** | Documentation | Other ]

# Short Description

1. Updated the nnunet client LR Scheduler
    - Now updates every step
    - Takes into account the total number of rounds when determining max step
    
2. Fixed an issue where RAM usage would steadily increase throughout training and cause OOM
    - Not sure if this issue was specific to the nnunet client or affects all clients
    - RAM usage would steadily increase after each round eventually leading to an OOM.
    - Resolved issue by running garbage collection at the beginning of each round. Implemented this only for the nnunet client using a hook.

3. Added Gradient Clipping to nnunet client
    - By default, nnunet 2.5.1 does gradient some gradient clipping during training
    - Added this to the nnunet client so that we could be consistent
    - In order to add this functionality, had to add another hook function to the basic client
    - This repository definitely needs a cleanup/refactor. Particularly Basic Client

4. Changed how plans files are named
    - Previously, if the client was asked to generate a plans file, it was named the nnunet default which is nnUNetPlans
    - The final plans file had a prefix to specify it was for FL, however if in a previous experiment another client was asked to generate the default plans, then those plans would have had the same name and been overwritten.
    - source plans are now named after the dataset from which they were generated
