### PR TITLE
Adding in Dirichlet allocation partitioner

### DIFF
--- a/fl4health/clients/nnunet_client.py
+++ b/fl4health/clients/nnunet_client.py
@@ -201,7 +201,11 @@ class NnunetClient(BasicClient):
         # Set the number of processes for each dataloader.
         if self.n_dataload_proc is None:
             # Nnunet default is 12 or max cpu's. We decrease max by 1 just in case
-            self.n_dataload_proc = min(12, len(os.sched_getaffinity(0)) - 1)
+            # NOTE: The type: ignore here is to skip issues where a local operating system is not compatible
+            # with sched_getaffinity (older versions of MacOS, for example). The code still won't run but mypy won't
+            # complain. Workarounds like using os.cpu_count(), while not exactly the same, are possible.
+            self.n_dataload_proc = min(12, len(os.sched_getaffinity(0)) - 1)  # type: ignore
+
         os.environ["nnUNet_n_proc_DA"] = str(self.n_dataload_proc)
 
         # The batchgenerators package used under the hood by the dataloaders creates an

--- a/fl4health/utils/dataset.py
+++ b/fl4health/utils/dataset.py
@@ -93,6 +93,16 @@ class SslTensorDataset(TensorDataset):
 
 class DictionaryDataset(Dataset):
     def __init__(self, data: Dict[str, List[torch.Tensor]], targets: torch.Tensor) -> None:
+        """
+        A torch dataset that supports a dictionary of input data rather than just a torch.Tensor. This kind of dataset
+        is useful when dealing with non-trivial inputs to a model. For example, a language model may require token ids
+        AND attention masks. This dataset supports that functionality.
+
+        Args:
+            data (Dict[str, List[torch.Tensor]]): A set of data for model training/input in the form of a dictionary
+                of tensors.
+            targets (torch.Tensor): Target tensor.
+        """
         self.data = data
         self.targets = targets
 
@@ -111,7 +121,8 @@ class SyntheticDataset(TensorDataset):
         targets: torch.Tensor,
     ):
         """
-        A dataset for synthetically created data strictly in the form of pytorch tensors.
+        A dataset for synthetically created data strictly in the form of pytorch tensors. Generally, this dataset
+        is just used for tests.
         Args:
             data (torch.Tensor): Data tensor with first dimension corresponding to the number of datapoints
             targets (torch.Tensor): Target tensor with first dimension corresponding to the number of datapoints
@@ -134,6 +145,20 @@ D = TypeVar("D", bound=Union[TensorDataset, DictionaryDataset])
 
 
 def select_by_indices(dataset: D, selected_indices: torch.Tensor) -> D:
+    """
+    This function is used to extract a subset of a dataset sliced by the indices in the tensor selected_indices. The
+    dataset returned should be of the same type as the input but with only data associated with the given indices.
+
+    Args:
+        dataset (D): Dataset to be "subsampled" using the provided indices.
+        selected_indices (torch.Tensor): Indices within the datasets data and targets (if they exist) to select
+
+    Raises:
+        TypeError: Will throw an error if the dataset provided is not supported
+
+    Returns:
+        D: Dataset with only the data associated with the provided indices. Must be of a supported type.
+    """
     if isinstance(dataset, TensorDataset):
         modified_dataset = copy.deepcopy(dataset)
         modified_dataset.data = dataset.data[selected_indices]

--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -30,6 +30,16 @@ class DirichletLabelBasedAllocation:
         np.random.dirichlet([1]*5): array([0.23645891, 0.08857052, 0.29519184, 0.2999956 , 0.07978313])
         np.random.dirichlet([1000]*5): array([0.2066252 , 0.19644968, 0.20080513, 0.19992536, 0.19619462])
 
+        Example Usage:
+            original_dataset = SyntheticDataset(
+                torch.rand((10000, 3, 3)),
+                torch.randint(low=0, high=10, size=(10000, 1))
+            )
+            heterogeneous_partitioner = DirichletLabelBasedAllocation(
+                number_of_partitions=10, unique_labels=list(range(10)), beta=10.0, min_label_examples=2
+            )
+            partitioned_datasets = heterogeneous_partitioner.partition_dataset(original_dataset, max_retries=5)
+
         Args:
             number_of_partitions (int): Number of new datasets that we want to break the current dataset into
             unique_labels (List[T]): This is the set of labels through which we'll iterate to perform allocation

--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -1,0 +1,99 @@
+import math
+from logging import INFO
+from typing import List, Optional, Tuple, TypeVar, Union
+
+import numpy as np
+import torch
+from flwr.common.logger import log
+
+from fl4health.utils.dataset import DictionaryDataset, TensorDataset, select_by_indices
+
+T = TypeVar("T")
+D = TypeVar("D", bound=Union[TensorDataset, DictionaryDataset])
+
+
+class LabelBasedDirichletAllocation:
+    def __init__(
+        self, number_of_partitions: int, unique_labels: List[T], beta: float, min_label_examples: Optional[int] = None
+    ) -> None:
+        self.number_of_partitions = number_of_partitions
+        self.unique_labels = unique_labels
+        self.n_unique_labels = len(unique_labels)
+        self.beta = beta
+        self.min_label_examples = min_label_examples if min_label_examples else 0
+
+    def partition_label_indices(self, label: T, label_indices: torch.Tensor) -> Tuple[List[torch.Tensor], int]:
+        """
+        Given a set of indices from the dataset corresponding to a particular label, the indices are allocated using
+        a Dirichlet distribution, to the partitions.
+
+        Args:
+            label_indices (torch.Tensor): Indices from the dataset corresponding to a particular label. This assumes
+                that the tensor is 1D and it's len constitutes the number of total datapoints with the label.
+
+        Returns:
+            List[torch.Tensor]: partitioned indices of datapoints with the corresponding label.
+        """
+        total_data_points_with_label = len(label_indices)
+        # These are the percentages of the label indices to be distributed for each partition
+        partition_allocations = np.random.dirichlet(np.repeat(self.beta, self.number_of_partitions))
+        log(
+            INFO,
+            (
+                f"The allocation distribution for label ({str(label)}) is {partition_allocations} "
+                f"using a beta of {self.beta}",
+            ),
+        )
+
+        num_samples_per_partition = [
+            math.floor(probability * total_data_points_with_label) for probability in partition_allocations
+        ]
+        log(INFO, f"Assignment of datapoints to partitions as {num_samples_per_partition}")
+        # Getting the smallest sample across the partitions to decided if it was acceptable.
+        min_samples = min(num_samples_per_partition)
+        total_samples_in_partitions = sum(num_samples_per_partition)
+        # Due to rounding, we need to make sure the partitions we're asking for sum to the total data points size.
+        # So our final partition will "fill" the difference and be discarded
+        num_samples_per_partition.append(total_data_points_with_label - total_samples_in_partitions)
+
+        shuffled_indices = label_indices[torch.randperm(total_data_points_with_label)]
+
+        # Partitioning of the indices according to the Dirichlet distribution.
+        partitioned_indices = list(torch.split(shuffled_indices, num_samples_per_partition))
+
+        # Dropping the last partition as they are "excess" indices
+        return partitioned_indices[:-1], min_samples
+
+    def partition_dataset(self, original_dataset: D, max_retries: int = 5) -> List[D]:
+        targets = original_dataset.targets
+        assert targets is not None, "A label-based partitioner requires targets but this dataset has no targets"
+        partitioned_indices = [torch.Tensor([]).int() for _ in range(self.number_of_partitions)]
+
+        partition_attempts = 0
+
+        for label in self.unique_labels:
+            label_indices = torch.where(targets == label)[0].int()
+            min_selected_labels = -1
+            while min_selected_labels < self.min_label_examples:
+                partitioned_indices_for_label, min_selected_labels = self.partition_label_indices(label, label_indices)
+                if min_selected_labels >= self.min_label_examples:
+                    for i, indices_for_label_partition in enumerate(partitioned_indices_for_label):
+                        partitioned_indices[i] = torch.cat((partitioned_indices[i], indices_for_label_partition))
+                else:
+                    partition_attempts += 1
+                    log(
+                        INFO,
+                        (
+                            f"Too few datapoints in a partition. One partition had {min_selected_labels} but the "
+                            f"minimum requested was {self.min_label_examples}. Resampling the partition..."
+                        ),
+                    )
+                    if partition_attempts == max_retries:
+                        raise ValueError(
+                            (
+                                f"Max Retries: {max_retries} reached. Partitioning failed to "
+                                "satisfy the minimum label threshold"
+                            )
+                        )
+
+        return [select_by_indices(original_dataset, indices) for indices in partitioned_indices]

--- a/fl4health/utils/sampler.py
+++ b/fl4health/utils/sampler.py
@@ -12,12 +12,14 @@ D = TypeVar("D", bound=Union[TensorDataset, DictionaryDataset])
 
 
 class LabelBasedSampler(ABC):
-    """
-    This is an abstract class to be extended to create dataset samplers
-    based on the class of samples.
-    """
 
     def __init__(self, unique_labels: List[Any]) -> None:
+        """
+        This is an abstract class to be extended to create dataset samplers based on the class of samples.
+
+        Args:
+            unique_labels (List[Any]): The full set of labels contained in the dataset.
+        """
         self.unique_labels = unique_labels
         self.num_classes = len(self.unique_labels)
 
@@ -27,15 +29,21 @@ class LabelBasedSampler(ABC):
 
 
 class MinorityLabelBasedSampler(LabelBasedSampler):
-    """
-    This class is used to subsample a dataset so the classes are distributed in a non-IID way.
-    In particular, the MinorityLabelBasedSampler explicitly downsamples classes based on the
-    downsampling_ratio and minority_labels args used to construct the object. Subsampling a dataset is
-    accomplished by calling the subsample method and passing a BaseDataset object. This will return
-    the resulting subsampled dataset.
-    """
-
     def __init__(self, unique_labels: List[T], downsampling_ratio: float, minority_labels: Set[T]) -> None:
+        """
+        This class is used to subsample a dataset so the classes are distributed in a non-IID way.
+        In particular, the MinorityLabelBasedSampler explicitly downsamples classes based on the
+        downsampling_ratio and minority_labels args used to construct the object. Subsampling a dataset is
+        accomplished by calling the subsample method and passing a BaseDataset object. This will return
+        the resulting subsampled dataset.
+
+        Args:
+            unique_labels (List[T]): The full set of labels contained in the dataset.
+            downsampling_ratio (float): The percentage to which the specified "minority" labels are downsampled. For
+                example, if a label L has 10 examples and the downsampling_ratio is 0.2, then 8 of the datapoints with
+                label L are discarded.
+            minority_labels (Set[T]): The labels subject to downsampling.
+        """
         super().__init__(unique_labels)
         self.downsampling_ratio = downsampling_ratio
         self.minority_labels = minority_labels
@@ -43,6 +51,12 @@ class MinorityLabelBasedSampler(LabelBasedSampler):
     def subsample(self, dataset: D) -> D:
         """
         Returns a new dataset where samples part of minority_labels are downsampled
+
+        Args:
+            dataset (D): Dataset to be modified, through downsampling on specified labels.
+
+        Returns:
+            D: New dataset with downsampled labels.
         """
         assert dataset.targets is not None, "A label-based sampler requires targets but this dataset has no targets"
         selected_indices_list: List[torch.Tensor] = []
@@ -61,29 +75,48 @@ class MinorityLabelBasedSampler(LabelBasedSampler):
         return select_by_indices(dataset, selected_indices)
 
     def _get_random_subsample(self, tensor_to_subsample: torch.Tensor, subsample_size: int) -> torch.Tensor:
+        """
+        Given a tensor a new tensor is created by selecting a set of rows from the original tensor of
+        size subsample_size
+
+        Args:
+            tensor_to_subsample (torch.Tensor): Tensor to be subsampled. Assumes that we're subsampling rows of the
+                tensor
+            subsample_size (int): How many rows we want to extract from the tensor.
+
+        Returns:
+            torch.Tensor: New tensor with subsampled rows
+        """
         # NOTE: Assumes subsampling on rows
         tensor_size = tensor_to_subsample.shape[0]
+        assert subsample_size < tensor_size
         permutation = torch.randperm(tensor_size)
         return tensor_to_subsample[permutation[:subsample_size]]
 
 
 class DirichletLabelBasedSampler(LabelBasedSampler):
-    """
-    class used to subsample a dataset so the classes of samples are distributed in a non-IID way.
-    In particular, the DirichletLabelBasedSampler uses a dirichlet distribution to determine the number
-    of samples from each class. The sampler is constructed by passing a beta parameter that determines
-    the level of heterogeneity and a sample_percentage that determines the relative size of the modified
-    dataset. Subsampling a dataset is accomplished by calling the subsample method and passing a BaseDataset object.
-    This will return the resulting subsampled dataset.
-
-    NOTE: The range for beta is (0, infinity). The larger the value of beta, the more evenly the multinomial
-    probability of the labels will be. The smaller beta is the more heterogeneous it is.
-
-    np.random.dirichlet([1]*5): array([0.23645891, 0.08857052, 0.29519184, 0.2999956 , 0.07978313])
-    np.random.dirichlet([1000]*5): array([0.2066252 , 0.19644968, 0.20080513, 0.19992536, 0.19619462])
-    """
-
     def __init__(self, unique_labels: List[Any], sample_percentage: float = 0.5, beta: float = 100) -> None:
+        """
+        class used to subsample a dataset so the classes of samples are distributed in a non-IID way.
+        In particular, the DirichletLabelBasedSampler uses a dirichlet distribution to determine the number
+        of samples from each class. The sampler is constructed by passing a beta parameter that determines
+        the level of heterogeneity and a sample_percentage that determines the relative size of the modified
+        dataset. Subsampling a dataset is accomplished by calling the subsample method and passing a BaseDataset
+        object. This will return the resulting subsampled dataset.
+
+        NOTE: The range for beta is (0, infinity). The larger the value of beta, the more evenly the multinomial
+        probability of the labels will be. The smaller beta is the more heterogeneous it is.
+
+        np.random.dirichlet([1]*5): array([0.23645891, 0.08857052, 0.29519184, 0.2999956 , 0.07978313])
+        np.random.dirichlet([1000]*5): array([0.2066252 , 0.19644968, 0.20080513, 0.19992536, 0.19619462])
+
+        Args:
+            unique_labels (List[Any]): The full set of labels contained in the dataset.
+            sample_percentage (float, optional): The downsampling of the entire dataset to do. For example, if this
+                value is 0.5 and the dataset is of size 100, we will end up with 50 total data points. Defaults to 0.5.
+            beta (float, optional): This controls the heterogeneity of the label sampling. The smaller the beta, the
+                more skewed the label assignments will be for the dataset. Defaults to 100.
+        """
         super().__init__(unique_labels)
         self.probabilities = np.random.dirichlet(np.repeat(beta, self.num_classes))
         self.sample_percentage = sample_percentage
@@ -91,8 +124,16 @@ class DirichletLabelBasedSampler(LabelBasedSampler):
     def subsample(self, dataset: D) -> D:
         """
         Returns a new dataset where samples are selected based on a dirichlet distribution over labels
+
+        Args:
+            dataset (D): Dataset to be modified, through downsampling on specified labels.
+
+        Returns:
+            D: New dataset with downsampled labels.
         """
         assert dataset.targets is not None, "A label-based sampler requires targets but this dataset has no targets"
+        assert self.sample_percentage <= 1.0
+
         total_num_samples = int(len(dataset) * self.sample_percentage)
         targets = dataset.targets
 

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -1,0 +1,86 @@
+import numpy as np
+import torch
+
+from fl4health.utils.dataset import SyntheticDataset
+from fl4health.utils.partitioners import LabelBasedDirichletAllocation
+
+
+def construct_synthetic_dataset() -> SyntheticDataset:
+    # set seed for creation
+    torch.manual_seed(42)
+    random_inputs = torch.rand((10000, 3, 3))
+    # Note high is exclusive here
+    random_labels = torch.randint(low=0, high=10, size=(10000, 1))
+    # unset seed thereafter
+    torch.seed()
+    return SyntheticDataset(random_inputs, random_labels)
+
+
+SYNTHETIC_DATASET = construct_synthetic_dataset()
+
+
+def test_dirichlet_allocation_partitioner() -> None:
+    # setting numpy seed for reproducibility
+    np.random.seed(42)
+    # Should be a fairly uniform partitioner with a large beta
+    uniform_partitioner = LabelBasedDirichletAllocation(
+        number_of_partitions=5, unique_labels=list(range(10)), beta=100.0
+    )
+    partitioned_datasets = uniform_partitioner.partition_dataset(SYNTHETIC_DATASET)
+
+    assert len(partitioned_datasets) == 5
+    partition_0_targets = partitioned_datasets[0].targets
+    partition_2_targets = partitioned_datasets[2].targets
+    partition_4_targets = partitioned_datasets[4].targets
+
+    assert partition_0_targets is not None
+    assert partition_2_targets is not None
+    assert partition_4_targets is not None
+
+    assert len(torch.where(partition_0_targets == 0)[0]) == 203
+    assert len(torch.where(partition_0_targets == 1)[0]) == 211
+    assert len(torch.where(partition_2_targets == 5)[0]) == 203
+    assert len(torch.where(partition_2_targets == 9)[0]) == 183
+    assert len(torch.where(partition_4_targets == 0)[0]) == 226
+    assert len(torch.where(partition_4_targets == 5)[0]) == 232
+
+    # Should be a skewed partitioner with a small beta
+    heterogeneous_partitioner = LabelBasedDirichletAllocation(
+        number_of_partitions=10, unique_labels=list(range(10)), beta=1.0, min_label_examples=2
+    )
+    partitioned_datasets = heterogeneous_partitioner.partition_dataset(SYNTHETIC_DATASET, max_retries=5)
+
+    assert len(partitioned_datasets) == 10
+    partition_0_targets = partitioned_datasets[0].targets
+    partition_2_targets = partitioned_datasets[2].targets
+    partition_6_targets = partitioned_datasets[6].targets
+    partition_7_targets = partitioned_datasets[7].targets
+    partition_9_targets = partitioned_datasets[9].targets
+
+    assert partition_0_targets is not None
+    assert partition_2_targets is not None
+    assert partition_6_targets is not None
+    assert partition_7_targets is not None
+    assert partition_9_targets is not None
+
+    assert len(partition_0_targets) == 943
+    assert len(partition_6_targets) == 846
+    assert len(partition_9_targets) == 816
+
+    assert len(torch.where(partition_0_targets == 0)[0]) == 25
+    assert len(torch.where(partition_0_targets == 1)[0]) == 180
+    assert len(torch.where(partition_0_targets == 5)[0]) == 7
+    assert len(torch.where(partition_0_targets == 9)[0]) == 243
+
+    assert len(torch.where(partition_2_targets == 0)[0]) == 34
+    assert len(torch.where(partition_2_targets == 1)[0]) == 133
+    assert len(torch.where(partition_2_targets == 5)[0]) == 200
+    assert len(torch.where(partition_2_targets == 9)[0]) == 173
+
+    assert len(torch.where(partition_7_targets == 0)[0]) == 204
+    assert len(torch.where(partition_7_targets == 1)[0]) == 45
+    assert len(torch.where(partition_7_targets == 5)[0]) == 33
+    assert len(torch.where(partition_7_targets == 8)[0]) == 27
+
+    # unset seed for safety
+    np.random.seed()

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 
 from fl4health.utils.dataset import SyntheticDataset
-from fl4health.utils.partitioners import LabelBasedDirichletAllocation
+from fl4health.utils.partitioners import DirichletLabelBasedAllocation
 
 
 def construct_synthetic_dataset() -> SyntheticDataset:
@@ -23,7 +23,7 @@ def test_dirichlet_allocation_partitioner() -> None:
     # setting numpy seed for reproducibility
     np.random.seed(42)
     # Should be a fairly uniform partitioner with a large beta
-    uniform_partitioner = LabelBasedDirichletAllocation(
+    uniform_partitioner = DirichletLabelBasedAllocation(
         number_of_partitions=5, unique_labels=list(range(10)), beta=100.0
     )
     partitioned_datasets = uniform_partitioner.partition_dataset(SYNTHETIC_DATASET)
@@ -45,7 +45,7 @@ def test_dirichlet_allocation_partitioner() -> None:
     assert len(torch.where(partition_4_targets == 5)[0]) == 232
 
     # Should be a skewed partitioner with a small beta
-    heterogeneous_partitioner = LabelBasedDirichletAllocation(
+    heterogeneous_partitioner = DirichletLabelBasedAllocation(
         number_of_partitions=10, unique_labels=list(range(10)), beta=1.0, min_label_examples=2
     )
     partitioned_datasets = heterogeneous_partitioner.partition_dataset(SYNTHETIC_DATASET, max_retries=5)


### PR DESCRIPTION
# PR Type
Feature

# Short Description

Clickup Ticket(s): [Link](https://app.clickup.com/t/8689qhwfz)

This PR adds in label-based Dirichlet partitioning. In the Dirichlet sampler that we have, we take an existing dataset and subsample the datapoints according to a Dirichlet distribution with a given $\beta$. In this partitioning example, we take an existing dataset and **split** it into pieces by iterating through the labels and use a Dirichlet distribution to assign a portion of those labels to each client. These two approaches are slightly different and both have been used in literature. 

However, the later is used in two benchmarks ([1](https://arxiv.org/pdf/2206.03655), [2](https://www.computer.org/csdl/journal/oj/2024/01/10316561/1S2UbvQk5Tq)), which, for future experiments, we'd like to reproduce.

# Tests Added

Added a test to ensure that the partitioning is happening as expected and has the right relationship to the Dirichlet $\beta$ parameter.
