### PR TITLE
Expanding ClientCheckpointModule to accept checkpointer sequences

### DIFF
--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -32,7 +32,7 @@ class TorchCheckpointer(ABC):
 
         Args:
             model (nn.Module): Model to potentially save via the checkpointer
-            loss (float): Computed loss associated with the model (if provided).
+            loss (float): Computed loss associated with the model.
             metrics (Dict[str, float]): Computed metrics associated with the model.
 
         Raises:

--- a/fl4health/checkpointing/client_module.py
+++ b/fl4health/checkpointing/client_module.py
@@ -1,12 +1,14 @@
 from enum import Enum
 from logging import INFO
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence, Union
 
 import torch.nn as nn
 from flwr.common.logger import log
 from flwr.common.typing import Scalar
 
 from fl4health.checkpointing.checkpointer import TorchCheckpointer
+
+CheckpointModuleInput = Optional[Union[TorchCheckpointer, Sequence[TorchCheckpointer]]]
 
 
 class CheckpointMode(Enum):
@@ -16,7 +18,7 @@ class CheckpointMode(Enum):
 
 class ClientCheckpointModule:
     def __init__(
-        self, pre_aggregation: Optional[TorchCheckpointer] = None, post_aggregation: Optional[TorchCheckpointer] = None
+        self, pre_aggregation: CheckpointModuleInput = None, post_aggregation: CheckpointModuleInput = None
     ) -> None:
         """
         This module is meant to hold up to two distinct client-side checkpointers.
@@ -29,35 +31,51 @@ class ClientCheckpointModule:
         That's because the target model for these methods is never globally aggregated. That is, they remain local
 
         Args:
-            pre_aggregation (Optional[TorchCheckpointer], optional): If defined, this checkpointer is used to
-                checkpoint models based on their validation metrics/losses **BEFORE** server-side aggregation.
-                Defaults to None.
-            post_aggregation (Optional[TorchCheckpointer], optional): If defined, this checkpointer is used to
-                checkpoint models based on their validation metrics/losses **AFTER** server-side aggregation.
-                Defaults to None.
+            pre_aggregation (CheckpointModuleInput, optional): If defined, this checkpointer (or sequence of
+                checkpointers) is used to checkpoint models based on their validation metrics/losses **BEFORE**
+                server-side aggregation. Defaults to None.
+            post_aggregation (CheckpointModuleInput, optional], optional): If defined, this checkpointer (or sequence
+                of checkpointers) is used to checkpoint models based on their validation metrics/losses **AFTER**
+                server-side aggregation. Defaults to None.
         """
-        self.pre_aggregation = pre_aggregation
-        self.post_aggregation = post_aggregation
+        self.pre_aggregation = [pre_aggregation] if isinstance(pre_aggregation, TorchCheckpointer) else pre_aggregation
+        self.post_aggregation = (
+            [post_aggregation] if isinstance(post_aggregation, TorchCheckpointer) else post_aggregation
+        )
 
     def maybe_checkpoint(
         self, model: nn.Module, loss: float, metrics: Dict[str, Scalar], mode: CheckpointMode
     ) -> None:
         """
-        If checkpointer exists, maybe checkpoint model based on the current comparison metric value.
+        If checkpointer or checkpoints indicated by the checkpoint mode exists, maybe checkpoint model based on the
+        model metrics or loss
 
         Args:
-            current_metric_value (float): The metric value obtained by the current model.
+            loss (float): The metric value obtained by the current model.
                 Used by checkpointer to decide whether to checkpoint the model.
             mode (CheckpointMode): Determines which of the checkpointers to use.
+
+        Args:
+            model (nn.Module): The model that might be checkpointed by the checkpointers.
+            loss (float): The loss value obtained by the current model. Potentially used by checkpointer to decide
+                whether to checkpoint the model.
+            metrics (Dict[str, Scalar]): The metrics obtained by the current model. Potentially used by checkpointer
+                to decide whether to checkpoint the model.
+            mode (CheckpointMode): Determines which of the checkpointers to use.
+
+        Raises:
+            ValueError: Thrown if the model provided is not recognized.
         """
         if mode == CheckpointMode.PRE_AGGREGATION:
             if self.pre_aggregation is not None:
-                self.pre_aggregation.maybe_checkpoint(model, loss, metrics)
+                for checkpointer in self.pre_aggregation:
+                    checkpointer.maybe_checkpoint(model, loss, metrics)
             else:
                 log(INFO, "No Pre-aggregation checkpoint specified. Skipping.")
         elif mode == CheckpointMode.POST_AGGREGATION:
             if self.post_aggregation is not None:
-                self.post_aggregation.maybe_checkpoint(model, loss, metrics)
+                for checkpointer in self.post_aggregation:
+                    checkpointer.maybe_checkpoint(model, loss, metrics)
             else:
                 log(INFO, "No Post-aggregation checkpoint specified. Skipping.")
         else:

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -1300,7 +1300,7 @@ class BasicClient(NumPyClient):
     def load_client_state(self) -> None:
         """
         Load checkpoint dict consisting of client name, total steps, lr schedulers, metrics
-            reporter and optimizers state. Method can be overriden to augment loaded checkpointed state.
+            reporter and optimizers state. Method can be overridden to augment loaded checkpointed state.
         """
         assert self.per_round_checkpointer is not None and self.per_round_checkpointer.checkpoint_exists()
 


### PR DESCRIPTION
Adding in the ability to pass multiple checkpointers to each of the pre and post aggregation components of the ClientCheckpointModule

# PR Type
Feature

# Short Description

Clickup Ticket(s): [Link](https://app.clickup.com/t/8689tgun7)

Add a short description of what is in this PR.

# Tests Added

Added a test that covers the case where pre-aggregation has a sequence of checkpointers and post aggregation only has one to test the mix. Also tested that the two different kinds of checkpointers exhibit the right behavior when used in the sequence.
