### PR TITLE
Quick update for partitioner to also get a prior rather than sampling

### DIFF
--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -19,7 +19,7 @@ class DirichletLabelBasedAllocation:
         unique_labels: List[T],
         min_label_examples: Optional[int] = None,
         beta: Optional[float] = None,
-        prior: Optional[Dict[T, np.ndarray]] = None,
+        prior_distribution: Optional[Dict[T, np.ndarray]] = None,
     ) -> None:
         """
         The class supports partitioning of a dataset into a set of datasets (of the same type) via Dirichlet
@@ -57,17 +57,17 @@ class DirichletLabelBasedAllocation:
             beta (Optional[float]): This controls the heterogeneity of the partition allocations. The smaller the beta,
               the more skewed the label assignments will be to different clients. It is mutually exclusive with the
               prior.
-            prior (Optional[Dict[T, np.ndarray]], optional): This is an optional input if you want to provide a prior
-              distribution for the Dirichlet distribution. This is useful if you want to make sure that the
-              partitioning of test data is similar to the partitioning of the training data. Defaults to None. It is
+            prior_distribution (Optional[Dict[T, np.ndarray]], optional): This is an optional input if you want to
+              provide a prior distribution for the Dirichlet distribution. This is useful if you want to make sure that
+              the partitioning of test data is similar to the partitioning of the training data. Defaults to None. It is
               mutually exclusive with the beta parameter.
         """
-        assert beta is not None or prior is not None, "Either beta or prior must be provided"
-        assert beta is None or prior is None, "Either beta or prior must be provided, not both"
+        assert beta is not None or prior_distribution is not None, "Either beta or prior must be provided"
+        assert beta is None or prior_distribution is None, "Either beta or prior must be provided, not both"
         self.number_of_partitions = number_of_partitions
         self.unique_labels = unique_labels
         self.n_unique_labels = len(unique_labels)
-        self.prior = prior
+        self.prior_distribution = prior_distribution
         self.beta = beta
         self.min_label_examples = min_label_examples if min_label_examples else 0
 
@@ -88,10 +88,15 @@ class DirichletLabelBasedAllocation:
             int: The minimum number of data points assigned to a partition.
             np.ndarray: The Dirichlet distribution used to partition the data points.
         """
-        if self.prior is not None:
-            assert len(self.prior) == self.n_unique_labels, "The length of the prior must match the number of labels"
-            partition_allocations = self.prior[label]
-            log(INFO, f"Using a prior distribution of {self.prior[label]} to allocate the label ({str(label)})")
+        if self.prior_distribution is not None:
+            assert (
+                len(self.prior_distribution) == self.n_unique_labels
+            ), "The length of the prior must match the number of labels"
+            partition_allocations = self.prior_distribution[label]
+            log(
+                INFO,
+                f"Using a prior distribution of {self.prior_distribution[label]} to allocate the label ({str(label)})",
+            )
         if self.beta is not None:
             total_data_points_with_label = len(label_indices)
             # These are the percentages of the label indices to be distributed for each partition

--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -78,8 +78,8 @@ class DirichletLabelBasedAllocation(Generic[T]):
             if self.min_label_examples > 0:
                 log(
                     WARN,
-                    """A prior distribution has been provided for the partitioner,
-                    so min_label_examples will be ignored""",
+                    "A prior distribution has been provided for the partitioner",
+                    "so min_label_examples will be ignored.",
                 )
 
     def partition_label_indices(
@@ -100,20 +100,21 @@ class DirichletLabelBasedAllocation(Generic[T]):
             np.ndarray: The Dirichlet distribution used to partition the data points.
         """
         if self.prior_distribution is not None:
+            label_prior_distribution = self.prior_distribution[label]
             assert (
-                len(self.prior_distribution[label]) == self.number_of_partitions
+                len(label_prior_distribution) == self.number_of_partitions
             ), f"The length of the prior distribution for label ({str(label)}) must match the number of partitions"
-            if sum(self.prior_distribution[label]) != 1:
+            if sum(label_prior_distribution) != 1:
                 log(
                     WARN,
                     f"The provided prior distribution for label ({str(label)}) does not sum to 1. "
                     "It will be normalized to sum to 1.",
                 )
-            partition_allocations = self.prior_distribution[label] / sum(self.prior_distribution[label])
+            partition_allocations = label_prior_distribution / sum(label_prior_distribution)
             log(
                 INFO,
                 f"The allocation distribution for label ({str(label)}) is {partition_allocations} "
-                f"using the provided prior distribution",
+                "using the provided prior distribution",
             )
         elif self.beta is not None:
             # These are the percentages of the label indices to be distributed for each partition

--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -1,6 +1,6 @@
 import math
 from logging import INFO
-from typing import List, Optional, Tuple, TypeVar, Union
+from typing import Dict, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
@@ -14,7 +14,12 @@ D = TypeVar("D", bound=Union[TensorDataset, DictionaryDataset])
 
 class DirichletLabelBasedAllocation:
     def __init__(
-        self, number_of_partitions: int, unique_labels: List[T], beta: float, min_label_examples: Optional[int] = None
+        self,
+        number_of_partitions: int,
+        unique_labels: List[T],
+        min_label_examples: Optional[int] = None,
+        beta: Optional[float] = None,
+        prior: Optional[Dict[T, np.ndarray]] = None,
     ) -> None:
         """
         The class supports partitioning of a dataset into a set of datasets (of the same type) via Dirichlet
@@ -43,22 +48,32 @@ class DirichletLabelBasedAllocation:
         Args:
             number_of_partitions (int): Number of new datasets that we want to break the current dataset into
             unique_labels (List[T]): This is the set of labels through which we'll iterate to perform allocation
-            beta (float): This controls the heterogeneity of the partition allocations. The smaller the beta, the
-                more skewed the label assignments will be to different clients.
             min_label_examples (Optional[int], optional): This is an optional input if you want to ensure a minimum
                 number of labels is present on each partition.
                 NOTE: This does not guarantee feasibility. That is, if you have a very small beta and request a large
                 minimum number here, you are unlikely to satisfy this request. In partitioning, if the minimum isn't
                 satisfied, we resample from the Dirichlet distribution. This is repeated some limited number of times.
                 Otherwise the partitioner "gives up". Defaults to None.
+            beta (Optional[float]): This controls the heterogeneity of the partition allocations. The smaller the beta,
+              the more skewed the label assignments will be to different clients. It is mutually exclusive with the
+              prior.
+            prior (Optional[Dict[T, np.ndarray]], optional): This is an optional input if you want to provide a prior
+              distribution for the Dirichlet distribution. This is useful if you want to make sure that the
+              partitioning of test data is similar to the partitioning of the training data. Defaults to None. It is
+              mutually exclusive with the beta parameter.
         """
+        assert beta is not None or prior is not None, "Either beta or prior must be provided"
+        assert beta is None or prior is None, "Either beta or prior must be provided, not both"
         self.number_of_partitions = number_of_partitions
         self.unique_labels = unique_labels
         self.n_unique_labels = len(unique_labels)
+        self.prior = prior
         self.beta = beta
         self.min_label_examples = min_label_examples if min_label_examples else 0
 
-    def partition_label_indices(self, label: T, label_indices: torch.Tensor) -> Tuple[List[torch.Tensor], int]:
+    def partition_label_indices(
+        self, label: T, label_indices: torch.Tensor
+    ) -> Tuple[List[torch.Tensor], int, np.ndarray]:
         """
         Given a set of indices from the dataset corresponding to a particular label, the indices are allocated using
         a Dirichlet distribution, to the partitions.
@@ -70,17 +85,24 @@ class DirichletLabelBasedAllocation:
 
         Returns:
             List[torch.Tensor]: partitioned indices of datapoints with the corresponding label.
+            int: The minimum number of data points assigned to a partition.
+            np.ndarray: The Dirichlet distribution used to partition the data points.
         """
-        total_data_points_with_label = len(label_indices)
-        # These are the percentages of the label indices to be distributed for each partition
-        partition_allocations = np.random.dirichlet(np.repeat(self.beta, self.number_of_partitions))
-        log(
-            INFO,
-            (
-                f"The allocation distribution for label ({str(label)}) is {partition_allocations} "
-                f"using a beta of {self.beta}",
-            ),
-        )
+        if self.prior is not None:
+            assert len(self.prior) == self.n_unique_labels, "The length of the prior must match the number of labels"
+            partition_allocations = self.prior[label]
+            log(INFO, f"Using a prior distribution of {self.prior[label]} to allocate the label ({str(label)})")
+        if self.beta is not None:
+            total_data_points_with_label = len(label_indices)
+            # These are the percentages of the label indices to be distributed for each partition
+            partition_allocations = np.random.dirichlet(np.repeat(self.beta, self.number_of_partitions))
+            log(
+                INFO,
+                (
+                    f"The allocation distribution for label ({str(label)}) is {partition_allocations} "
+                    f"using a beta of {self.beta}",
+                ),
+            )
 
         num_samples_per_partition = [
             math.floor(probability * total_data_points_with_label) for probability in partition_allocations
@@ -99,9 +121,9 @@ class DirichletLabelBasedAllocation:
         partitioned_indices = list(torch.split(shuffled_indices, num_samples_per_partition))
 
         # Dropping the last partition as they are "excess" indices
-        return partitioned_indices[:-1], min_samples
+        return partitioned_indices[:-1], min_samples, partition_allocations
 
-    def partition_dataset(self, original_dataset: D, max_retries: int = 5) -> List[D]:
+    def partition_dataset(self, original_dataset: D, max_retries: int = 5) -> Tuple[List[D], Dict[T, np.ndarray]]:
         """
         Attempts partitioning of the original dataset up to max_retries times. Retries are potentially required if
         the user requests a minimum number of labels be assigned to each of the partitions. If the drawn Dirichlet
@@ -118,19 +140,23 @@ class DirichletLabelBasedAllocation:
 
         Returns:
             List[D]: The partitioned datasets, length should correspond to self.number_of_partitions
+
         """
         targets = original_dataset.targets
         assert targets is not None, "A label-based partitioner requires targets but this dataset has no targets"
         partitioned_indices = [torch.Tensor([]).int() for _ in range(self.number_of_partitions)]
 
         partition_attempts = 0
-
+        partitioned_probabilities: Dict = {}
         for label in self.unique_labels:
             label_indices = torch.where(targets == label)[0].int()
             min_selected_labels = -1
             while min_selected_labels < self.min_label_examples:
-                partitioned_indices_for_label, min_selected_labels = self.partition_label_indices(label, label_indices)
+                partitioned_indices_for_label, min_selected_labels, partitioned_probability = (
+                    self.partition_label_indices(label, label_indices)
+                )
                 if min_selected_labels >= self.min_label_examples:
+                    partitioned_probabilities[label] = partitioned_probability
                     for i, indices_for_label_partition in enumerate(partitioned_indices_for_label):
                         partitioned_indices[i] = torch.cat((partitioned_indices[i], indices_for_label_partition))
                 else:
@@ -150,4 +176,6 @@ class DirichletLabelBasedAllocation:
                             )
                         )
 
-        return [select_by_indices(original_dataset, indices) for indices in partitioned_indices]
+        return [
+            select_by_indices(original_dataset, indices) for indices in partitioned_indices
+        ], partitioned_probabilities

--- a/fl4health/utils/partitioners.py
+++ b/fl4health/utils/partitioners.py
@@ -59,8 +59,8 @@ class DirichletLabelBasedAllocation:
               prior distribution..
             prior_distribution (Optional[Dict[T, np.ndarray]], optional): This is an optional input if you want to
               provide a prior distribution for the Dirichlet distribution. This is useful if you want to make sure that
-              the partitioning of test data is similar to the partitioning of the training data. Defaults to None. It is
-              mutually exclusive with the beta parameter and min_label_examples.
+              the partitioning of test data is similar to the partitioning of the training data. Defaults to None. It
+              is mutually exclusive with the beta parameter and min_label_examples.
         """
         assert beta is not None or prior_distribution is not None, "Either beta or prior must be provided"
         assert beta is None or prior_distribution is None, "Either beta or prior must be provided, not both"

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -169,23 +169,17 @@ def test_dirichlet_allocation_partitioner_with_prior_distribution() -> None:
     assert partition_9_targets_2 is not None
 
     assert len(partition_0_targets_2) == len(partition_0_targets_1)
+    assert len(partition_2_targets_2) == len(partition_2_targets_1)
     assert len(partition_6_targets_2) == len(partition_6_targets_1)
+    assert len(partition_7_targets_2) == len(partition_7_targets_1)
     assert len(partition_9_targets_2) == len(partition_9_targets_1)
-
-    assert len(torch.where(partition_0_targets_2 == 0)[0]) == len(torch.where(partition_0_targets_1 == 0)[0])
-    assert len(torch.where(partition_0_targets_2 == 1)[0]) == len(torch.where(partition_0_targets_1 == 1)[0])
-    assert len(torch.where(partition_0_targets_2 == 5)[0]) == len(torch.where(partition_0_targets_1 == 5)[0])
-    assert len(torch.where(partition_0_targets_2 == 9)[0]) == len(torch.where(partition_0_targets_1 == 9)[0])
-
-    assert len(torch.where(partition_2_targets_2 == 0)[0]) == len(torch.where(partition_2_targets_1 == 0)[0])
-    assert len(torch.where(partition_2_targets_2 == 1)[0]) == len(torch.where(partition_2_targets_1 == 1)[0])
-    assert len(torch.where(partition_2_targets_2 == 5)[0]) == len(torch.where(partition_2_targets_1 == 5)[0])
-    assert len(torch.where(partition_2_targets_2 == 9)[0]) == len(torch.where(partition_2_targets_1 == 9)[0])
-
-    assert len(torch.where(partition_7_targets_2 == 0)[0]) == len(torch.where(partition_7_targets_1 == 0)[0])
-    assert len(torch.where(partition_7_targets_2 == 1)[0]) == len(torch.where(partition_7_targets_1 == 1)[0])
-    assert len(torch.where(partition_7_targets_2 == 5)[0]) == len(torch.where(partition_7_targets_1 == 5)[0])
-    assert len(torch.where(partition_7_targets_2 == 8)[0]) == len(torch.where(partition_7_targets_1 == 8)[0])
+    
+    for i in range(10):
+        assert len(torch.where(partition_0_targets_2 == i)[0]) == len(torch.where(partition_0_targets_1 == i)[0])
+        assert len(torch.where(partition_2_targets_2 == i)[0]) == len(torch.where(partition_2_targets_1 == i)[0])
+        assert len(torch.where(partition_6_targets_2 == i)[0]) == len(torch.where(partition_6_targets_1 == i)[0])
+        assert len(torch.where(partition_7_targets_2 == i)[0]) == len(torch.where(partition_7_targets_1 == i)[0])
+        assert len(torch.where(partition_9_targets_2 == i)[0]) == len(torch.where(partition_9_targets_1 == i)[0])
 
     # unset seed for safety
     np.random.seed()

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -173,7 +173,7 @@ def test_dirichlet_allocation_partitioner_with_prior_distribution() -> None:
     assert len(partition_6_targets_2) == len(partition_6_targets_1)
     assert len(partition_7_targets_2) == len(partition_7_targets_1)
     assert len(partition_9_targets_2) == len(partition_9_targets_1)
-    
+
     for i in range(10):
         assert len(torch.where(partition_0_targets_2 == i)[0]) == len(torch.where(partition_0_targets_1 == i)[0])
         assert len(torch.where(partition_2_targets_2 == i)[0]) == len(torch.where(partition_2_targets_1 == i)[0])

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 from fl4health.utils.dataset import SyntheticDataset
@@ -81,6 +82,110 @@ def test_dirichlet_allocation_partitioner() -> None:
     assert len(torch.where(partition_7_targets == 1)[0]) == 45
     assert len(torch.where(partition_7_targets == 5)[0]) == 33
     assert len(torch.where(partition_7_targets == 8)[0]) == 27
+
+    # unset seed for safety
+    np.random.seed()
+
+
+def test_dirichlet_allocation_partitioner_with_prior_distribution() -> None:
+    # setting numpy seed for reproducibility
+    np.random.seed(42)
+    number_of_partitions = 5
+    unique_labels = list(range(10))
+    prior_distribution = {
+        label: np.array([partition + label + 1 for partition in range(number_of_partitions)])
+        for label in unique_labels
+    }
+    # Partitioner with a given prior distribution
+    prior_based_partitioner = DirichletLabelBasedAllocation(
+        number_of_partitions=number_of_partitions, unique_labels=unique_labels, prior_distribution=prior_distribution
+    )
+    partitioned_datasets, _ = prior_based_partitioner.partition_dataset(SYNTHETIC_DATASET)
+
+    assert len(partitioned_datasets) == 5
+    partition_0_targets = partitioned_datasets[0].targets
+    partition_2_targets = partitioned_datasets[2].targets
+    partition_4_targets = partitioned_datasets[4].targets
+
+    assert partition_0_targets is not None
+    assert partition_2_targets is not None
+    assert partition_4_targets is not None
+
+    assert len(torch.where(partition_0_targets == 0)[0]) == 66
+    assert len(torch.where(partition_0_targets == 1)[0]) == 96
+    assert len(torch.where(partition_2_targets == 5)[0]) == 211
+    assert len(torch.where(partition_2_targets == 9)[0]) == 194
+    assert len(torch.where(partition_4_targets == 0)[0]) == 333
+    assert len(torch.where(partition_4_targets == 5)[0]) == 263
+
+    # Test passing output of the first partitioner as prior distribution to the second partitioner
+    first_partitioner = DirichletLabelBasedAllocation(
+        number_of_partitions=10, unique_labels=list(range(10)), beta=1.0, min_label_examples=2
+    )
+    partitioned_datasets_1, partitioned_distribution_1 = first_partitioner.partition_dataset(
+        SYNTHETIC_DATASET, max_retries=5
+    )
+
+    assert len(partitioned_datasets_1) == 10
+    partition_0_targets_1 = partitioned_datasets_1[0].targets
+    partition_2_targets_1 = partitioned_datasets_1[2].targets
+    partition_6_targets_1 = partitioned_datasets_1[6].targets
+    partition_7_targets_1 = partitioned_datasets_1[7].targets
+    partition_9_targets_1 = partitioned_datasets_1[9].targets
+
+    assert partition_0_targets_1 is not None
+    assert partition_2_targets_1 is not None
+    assert partition_6_targets_1 is not None
+    assert partition_7_targets_1 is not None
+    assert partition_9_targets_1 is not None
+
+    second_partitioner = DirichletLabelBasedAllocation(
+        number_of_partitions=10, unique_labels=list(range(10)), prior_distribution=partitioned_distribution_1
+    )
+
+    partitioned_datasets_2, partitioned_distribution_2 = second_partitioner.partition_dataset(
+        SYNTHETIC_DATASET, max_retries=5
+    )
+
+    # Check that the partitioned distributions are the same
+    for key in partitioned_distribution_1.keys():
+        for partition in range(10):
+            assert (
+                pytest.approx(partitioned_distribution_1[key][partition], abs=0.00001)
+                == partitioned_distribution_2[key][partition]
+            )
+
+    assert len(partitioned_datasets_2) == 10
+    partition_0_targets_2 = partitioned_datasets_2[0].targets
+    partition_2_targets_2 = partitioned_datasets_2[2].targets
+    partition_6_targets_2 = partitioned_datasets_2[6].targets
+    partition_7_targets_2 = partitioned_datasets_2[7].targets
+    partition_9_targets_2 = partitioned_datasets_2[9].targets
+
+    assert partition_0_targets_2 is not None
+    assert partition_2_targets_2 is not None
+    assert partition_6_targets_2 is not None
+    assert partition_7_targets_2 is not None
+    assert partition_9_targets_2 is not None
+
+    assert len(partition_0_targets_2) == len(partition_0_targets_1)
+    assert len(partition_6_targets_2) == len(partition_6_targets_1)
+    assert len(partition_9_targets_2) == len(partition_9_targets_1)
+
+    assert len(torch.where(partition_0_targets_2 == 0)[0]) == len(torch.where(partition_0_targets_1 == 0)[0])
+    assert len(torch.where(partition_0_targets_2 == 1)[0]) == len(torch.where(partition_0_targets_1 == 1)[0])
+    assert len(torch.where(partition_0_targets_2 == 5)[0]) == len(torch.where(partition_0_targets_1 == 5)[0])
+    assert len(torch.where(partition_0_targets_2 == 9)[0]) == len(torch.where(partition_0_targets_1 == 9)[0])
+
+    assert len(torch.where(partition_2_targets_2 == 0)[0]) == len(torch.where(partition_2_targets_1 == 0)[0])
+    assert len(torch.where(partition_2_targets_2 == 1)[0]) == len(torch.where(partition_2_targets_1 == 1)[0])
+    assert len(torch.where(partition_2_targets_2 == 5)[0]) == len(torch.where(partition_2_targets_1 == 5)[0])
+    assert len(torch.where(partition_2_targets_2 == 9)[0]) == len(torch.where(partition_2_targets_1 == 9)[0])
+
+    assert len(torch.where(partition_7_targets_2 == 0)[0]) == len(torch.where(partition_7_targets_1 == 0)[0])
+    assert len(torch.where(partition_7_targets_2 == 1)[0]) == len(torch.where(partition_7_targets_1 == 1)[0])
+    assert len(torch.where(partition_7_targets_2 == 5)[0]) == len(torch.where(partition_7_targets_1 == 5)[0])
+    assert len(torch.where(partition_7_targets_2 == 8)[0]) == len(torch.where(partition_7_targets_1 == 8)[0])
 
     # unset seed for safety
     np.random.seed()

--- a/tests/utils/partitioners_test.py
+++ b/tests/utils/partitioners_test.py
@@ -26,7 +26,7 @@ def test_dirichlet_allocation_partitioner() -> None:
     uniform_partitioner = DirichletLabelBasedAllocation(
         number_of_partitions=5, unique_labels=list(range(10)), beta=100.0
     )
-    partitioned_datasets = uniform_partitioner.partition_dataset(SYNTHETIC_DATASET)
+    partitioned_datasets, _ = uniform_partitioner.partition_dataset(SYNTHETIC_DATASET)
 
     assert len(partitioned_datasets) == 5
     partition_0_targets = partitioned_datasets[0].targets
@@ -48,7 +48,7 @@ def test_dirichlet_allocation_partitioner() -> None:
     heterogeneous_partitioner = DirichletLabelBasedAllocation(
         number_of_partitions=10, unique_labels=list(range(10)), beta=1.0, min_label_examples=2
     )
-    partitioned_datasets = heterogeneous_partitioner.partition_dataset(SYNTHETIC_DATASET, max_retries=5)
+    partitioned_datasets, _ = heterogeneous_partitioner.partition_dataset(SYNTHETIC_DATASET, max_retries=5)
 
     assert len(partitioned_datasets) == 10
     partition_0_targets = partitioned_datasets[0].targets


### PR DESCRIPTION
# PR Type
[Fix]

# Short Description

This update to the partitioner allows it to retrieve a prior distribution instead of generating a random one.

# Tests Added

Updated tests to support extra output.
