### PR TITLE
Fixing the tests for Mk-MMD loss such that they still pass properly on a GPU and CPU

### DIFF
--- a/fl4health/losses/mkmmd_loss.py
+++ b/fl4health/losses/mkmmd_loss.py
@@ -46,7 +46,7 @@ class MkMmdLoss(torch.nn.Module):
             default_gamma_powers = torch.arange(-3.5, 1.25, 0.25, device=device)
             self.gammas = torch.pow(2.0, default_gamma_powers)
         else:
-            self.gammas = gammas
+            self.gammas = gammas.to(self.device)
         self.kernel_num = len(self.gammas)
 
         if betas is None:

--- a/tests/losses/test_mkmmd_loss.py
+++ b/tests/losses/test_mkmmd_loss.py
@@ -4,6 +4,8 @@ from torch.distributions import MultivariateNormal
 
 from fl4health.losses.mkmmd_loss import MkMmdLoss
 
+DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
 X = torch.Tensor(
     [
         [1, 1, 1],
@@ -18,7 +20,7 @@ X = torch.Tensor(
         [4, 2, 1],
         [1, 1, 1],
     ]
-)
+).to(DEVICE)
 Y = torch.Tensor(
     [
         [4, 3, 4],
@@ -33,9 +35,7 @@ Y = torch.Tensor(
         [4, 1, 4],
         [2, 2, 2],
     ]
-)
-
-DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+).to(DEVICE)
 
 mkmmd_loss_linear = MkMmdLoss(DEVICE, gammas=torch.Tensor([2, 1, 1 / 2]), perform_linear_approximation=True)
 mkmmd_loss_linear.betas = torch.Tensor([1.5, 2.0, -1.0]).reshape(-1, 1).to(DEVICE)
@@ -75,7 +75,7 @@ def test_construct_quadruples() -> None:
             [[4, 3, 3], [3, 3, 2], [2, 2, 1], [2, 3, 4]],
             [[4, 4, 4], [4, 2, 1], [3, 2, 1], [4, 1, 4]],
         ]
-    )
+    ).to(DEVICE)
     assert torch.all(quads.eq(quads_target))
 
 
@@ -107,36 +107,36 @@ def test_inner_product_calculations_all() -> None:
     inner_product_x3_x3 = 0.0
     inner_product_x1_x2 = (3.0 - 4.0) * (3.0 - 4.0) + (4.0 - 2.0) * (4.0 - 2.0) + (4.0 - 1.0) * (4.0 - 1.0)
     # Index into XX'
-    pytest.approx(inner_products_all[0, 3, 3], abs=0.0001) == inner_product_x3_x3
-    pytest.approx(inner_products_all[0, 1, 2], abs=0.0001) == inner_product_x1_x2
+    pytest.approx(inner_products_all[0, 3, 3].cpu(), abs=0.0001) == inner_product_x3_x3
+    pytest.approx(inner_products_all[0, 1, 2].cpu(), abs=0.0001) == inner_product_x1_x2
     # Should be symmetric
-    pytest.approx(inner_products_all[0, 2, 1], abs=0.0001) == inner_product_x1_x2
+    pytest.approx(inner_products_all[0, 2, 1].cpu(), abs=0.0001) == inner_product_x1_x2
 
     inner_product_x1_y1 = (3.0 - 1.0) * (3.0 - 1.0) + (4.0 - 2.0) * (4.0 - 2.0) + (4.0 - 2.0) * (4.0 - 2.0)
     inner_product_x1_y3 = (3.0 - 1.0) * (3.0 - 1.0) + (4.0 - 4.0) * (4.0 - 4.0) + (4.0 - 2.0) * (4.0 - 2.0)
     # Index into XY'
-    pytest.approx(inner_products_all[2, 1, 1], abs=0.0001) == inner_product_x1_y1
-    pytest.approx(inner_products_all[2, 1, 3], abs=0.0001) == inner_product_x1_y3
+    pytest.approx(inner_products_all[2, 1, 1].cpu(), abs=0.0001) == inner_product_x1_y1
+    pytest.approx(inner_products_all[2, 1, 3].cpu(), abs=0.0001) == inner_product_x1_y3
     # Should be transpose in X'Y
-    pytest.approx(inner_products_all[3, 1, 1], abs=0.0001) == inner_product_x1_y1
-    pytest.approx(inner_products_all[3, 3, 1], abs=0.0001) == inner_product_x1_y3
+    pytest.approx(inner_products_all[3, 1, 1].cpu(), abs=0.0001) == inner_product_x1_y1
+    pytest.approx(inner_products_all[3, 3, 1].cpu(), abs=0.0001) == inner_product_x1_y3
 
     inner_product_y2_y2 = 0.0
     inner_product_y5_y8 = (4.0 - 3.0) * (4.0 - 3.0) + (1.0 - 2.0) * (1.0 - 2.0) + (2.0 - 1.0) * (2.0 - 1.0)
     # Index into YY'
-    pytest.approx(inner_products_all[1, 2, 2], abs=0.0001) == inner_product_y2_y2
-    pytest.approx(inner_products_all[1, 5, 8], abs=0.0001) == inner_product_y5_y8
+    pytest.approx(inner_products_all[1, 2, 2].cpu(), abs=0.0001) == inner_product_y2_y2
+    pytest.approx(inner_products_all[1, 5, 8].cpu(), abs=0.0001) == inner_product_y5_y8
     # Should be symmetric
-    pytest.approx(inner_products_all[1, 8, 5], abs=0.0001) == inner_product_y5_y8
+    pytest.approx(inner_products_all[1, 8, 5].cpu(), abs=0.0001) == inner_product_y5_y8
 
     inner_product_y1_x1 = (1.0 - 3.0) * (1.0 - 3.0) + (2.0 - 4.0) * (2.0 - 4.0) + (2.0 - 4.0) * (2.0 - 4.0)
     inner_product_y3_x3 = (1.0 - 2.0) * (1.0 - 2.0) + (4.0 - 1.0) * (4.0 - 1.0) + (2.0 - 4.0) * (2.0 - 4.0)
     # Index into X'Y
-    pytest.approx(inner_products_all[3, 1, 1], abs=0.0001) == inner_product_y1_x1
-    pytest.approx(inner_products_all[3, 3, 3], abs=0.0001) == inner_product_y3_x3
+    pytest.approx(inner_products_all[3, 1, 1].cpu(), abs=0.0001) == inner_product_y1_x1
+    pytest.approx(inner_products_all[3, 3, 3].cpu(), abs=0.0001) == inner_product_y3_x3
     # Should be transpose in X'Y, but we're looking at the diagonal
-    pytest.approx(inner_products_all[2, 1, 1], abs=0.0001) == inner_product_y1_x1
-    pytest.approx(inner_products_all[2, 3, 1], abs=0.0001) == inner_product_y3_x3
+    pytest.approx(inner_products_all[2, 1, 1].cpu(), abs=0.0001) == inner_product_y1_x1
+    pytest.approx(inner_products_all[2, 3, 1].cpu(), abs=0.0001) == inner_product_y3_x3
 
 
 def test_compute_h_u_from_inner_products_linear() -> None:
@@ -149,11 +149,11 @@ def test_compute_h_u_from_inner_products_linear() -> None:
     assert h_u_gamma_2.shape == (1, 5)
 
     # The fourth entry should coincide with computing h_u(v_4), so we compute h_u using the 4th inner product entry
-    h_u_components_gamma_1_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])) / gamma_1)
+    h_u_components_gamma_1_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])).to(DEVICE) / gamma_1)
     # For the other gamma, the fourth entry should coincide with computing h_u(v_4), so we compute h_u using the
     # 4th inner product entry
-    h_u_components_gamma_2_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])) / gamma_2)
-    h_u_components_gamma_2_0_target = torch.exp((-1 * torch.Tensor([22, 14, 2, 2])) / gamma_2)
+    h_u_components_gamma_2_3_target = torch.exp((-1 * torch.Tensor([2, 10, 5, 3])).to(DEVICE) / gamma_2)
+    h_u_components_gamma_2_0_target = torch.exp((-1 * torch.Tensor([22, 14, 2, 2])).to(DEVICE) / gamma_2)
 
     h_u_gamma_1_3_target = (
         h_u_components_gamma_1_3_target[0]
@@ -192,17 +192,17 @@ def test_compute_h_u_from_inner_products() -> None:
 
     # Looking at the j=3, k=5 entry for gamma_1, this should correspond to the pairs
     # (x_3, x_5), (y_3, y_5), (x_3, y_5), (y_3, x_5)
-    h_u_components_gamma_1_3_5_target = torch.exp((-1 * torch.Tensor([10, 18, 8, 8])) / gamma_1)
+    h_u_components_gamma_1_3_5_target = torch.exp((-1 * torch.Tensor([10, 18, 8, 8])).to(DEVICE) / gamma_1)
     # Looking at the j=10, k=4 entry for gamma_1, this should correspond to the pairs
     # (x_10, x_4), (y_10, y_4), (x_10, y_4), (y_10, x_4)
-    h_u_components_gamma_1_10_4_target = torch.exp((-1 * torch.Tensor([1, 8, 19, 2])) / gamma_1)
+    h_u_components_gamma_1_10_4_target = torch.exp((-1 * torch.Tensor([1, 8, 19, 2])).to(DEVICE) / gamma_1)
 
     # Looking at the j=0, k=1 entry for gamma_2, this should correspond to the pairs
     # (x_0, x_1), (y_0, y_1), (x_0, y_1), (y_0, x_1)
-    h_u_components_gamma_2_0_1_target = torch.exp((-1 * torch.Tensor([20, 14, 2, 2])) / gamma_2)
+    h_u_components_gamma_2_0_1_target = torch.exp((-1 * torch.Tensor([20, 14, 2, 2])).to(DEVICE) / gamma_2)
     # Looking at the j=9, k=4 entry for gamma_2, this should correspond to the pairs
     # (x_9, x_4), (y_9, y_4), (x_9, y_4), (y_9, x_4)
-    h_u_components_gamma_2_9_4_target = torch.exp((-1 * torch.Tensor([9, 1, 9, 19])) / gamma_2)
+    h_u_components_gamma_2_9_4_target = torch.exp((-1 * torch.Tensor([9, 1, 9, 19])).to(DEVICE) / gamma_2)
 
     h_u_gamma_1_3_5_target = (
         h_u_components_gamma_1_3_5_target[0]
@@ -294,7 +294,7 @@ def test_compute_mkmmd_linear() -> None:
         + hat_d_per_kernel_linear[1, 0] * 2.0
         + hat_d_per_kernel_linear[2, 0] * (-1.0)
     )
-    assert pytest.approx(mkmmd_loss_linear.compute_mkmmd(X, Y, betas), abs=0.0001) == mkmmd_target
+    assert pytest.approx(mkmmd_loss_linear.compute_mkmmd(X, Y, betas).cpu(), abs=0.0001) == mkmmd_target.cpu()
 
 
 def test_compute_hat_d_per_kernel() -> None:
@@ -319,7 +319,7 @@ def test_compute_mkmmd() -> None:
     mkmmd_target = (
         hat_d_per_kernel_all[0, 0] * 1.5 + hat_d_per_kernel_all[1, 0] * 2.0 + hat_d_per_kernel_all[2, 0] * (-1.0)
     )
-    assert pytest.approx(mkmmd_loss.compute_mkmmd(X, Y, betas), abs=0.0001) == mkmmd_target
+    assert pytest.approx(mkmmd_loss.compute_mkmmd(X, Y, betas).cpu(), abs=0.0001) == mkmmd_target.cpu()
 
 
 def test_create_h_u_delta_w_i() -> None:
@@ -373,13 +373,16 @@ def test_form_kernel_samples_minus_expectation() -> None:
     kernel_samples_minus_expectation_2_0_1 = all_h_us_all[2, 0, 1] - hat_d_per_kernel_all[2, 0]
 
     assert (
-        pytest.approx(kernel_samples_minus_expectation_0_3_5, abs=0.00001) == kernel_samples_minus_expectation[0, 3, 5]
+        pytest.approx(kernel_samples_minus_expectation_0_3_5.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[0, 3, 5].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_1_3_5, abs=0.00001) == kernel_samples_minus_expectation[1, 3, 5]
+        pytest.approx(kernel_samples_minus_expectation_1_3_5.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[1, 3, 5].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_2_0_1, abs=0.00001) == kernel_samples_minus_expectation[2, 0, 1]
+        pytest.approx(kernel_samples_minus_expectation_2_0_1.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[2, 0, 1].cpu()
     )
 
     kernel_samples_minus_expectation_0_7_2 = all_h_us_all[0, 7, 2] - hat_d_per_kernel_all[0, 0]
@@ -387,13 +390,16 @@ def test_form_kernel_samples_minus_expectation() -> None:
     kernel_samples_minus_expectation_2_1_1 = all_h_us_all[2, 1, 1] - hat_d_per_kernel_all[2, 0]
 
     assert (
-        pytest.approx(kernel_samples_minus_expectation_0_7_2, abs=0.00001) == kernel_samples_minus_expectation[0, 7, 2]
+        pytest.approx(kernel_samples_minus_expectation_0_7_2.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[0, 7, 2].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_1_9_1, abs=0.00001) == kernel_samples_minus_expectation[1, 9, 1]
+        pytest.approx(kernel_samples_minus_expectation_1_9_1.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[1, 9, 1].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_2_1_1, abs=0.00001) == kernel_samples_minus_expectation[2, 1, 1]
+        pytest.approx(kernel_samples_minus_expectation_2_1_1.cpu(), abs=0.00001) 
+            == kernel_samples_minus_expectation[2, 1, 1].cpu()
     )
 
 
@@ -417,14 +423,14 @@ def test_compute_Q_k() -> None:
     Q_k_1_2 = (1 / (121 - 1)) * unrolled_summation(1, 2)
     Q_k_2_1 = (1 / (121 - 1)) * unrolled_summation(2, 1)
     # Should be symmetric
-    pytest.approx(Q_k_1_0, abs=0.00001) == Q_k_0_1
-    pytest.approx(Q_k_1_2, abs=0.00001) == Q_k_2_1
+    pytest.approx(Q_k_1_0.cpu(), abs=0.00001) == Q_k_0_1.cpu()
+    pytest.approx(Q_k_1_2.cpu(), abs=0.00001) == Q_k_2_1.cpu()
 
-    pytest.approx(Q_k[0, 0], abs=0.00001) == Q_k_0_0
-    pytest.approx(Q_k[1, 0], abs=0.00001) == Q_k_1_0
-    pytest.approx(Q_k[0, 1], abs=0.00001) == Q_k_0_1
-    pytest.approx(Q_k[1, 2], abs=0.00001) == Q_k_1_2
-    pytest.approx(Q_k[2, 1], abs=0.00001) == Q_k_2_1
+    pytest.approx(Q_k[0, 0].cpu(), abs=0.00001) == Q_k_0_0.cpu()
+    pytest.approx(Q_k[1, 0].cpu(), abs=0.00001) == Q_k_1_0.cpu()
+    pytest.approx(Q_k[0, 1].cpu(), abs=0.00001) == Q_k_0_1.cpu()
+    pytest.approx(Q_k[1, 2].cpu(), abs=0.00001) == Q_k_1_2.cpu()
+    pytest.approx(Q_k[2, 1].cpu(), abs=0.00001) == Q_k_2_1.cpu()
 
 
 def test_beta_with_largest_hat_d() -> None:
@@ -472,7 +478,7 @@ def test_gamma_defaults() -> None:
     neg_gamma_powers = [-3.5, -3.25, -3, -2.75, -2.5, -2.25, -2, -1.75, -1.5, -1.25, -1, -0.75, -0.5, -0.25, 0]
     pos_gamma_powers = [0.25, 0.5, 0.75, 1]
     gamma_powers = neg_gamma_powers + pos_gamma_powers
-    default_gammas = torch.Tensor([2**power for power in gamma_powers])
+    default_gammas = torch.Tensor([2**power for power in gamma_powers]).to(DEVICE)
     assert torch.all(default_mkmmd.gammas.eq(default_gammas))
     assert torch.all(torch.where(default_mkmmd.betas >= 0.0, True, False))
     assert pytest.approx(torch.sum(default_mkmmd.betas).item(), abs=0.0001) == 1.0
@@ -487,7 +493,7 @@ def test_get_best_vertex_for_objective_function() -> None:
     assert pytest.approx(best_vertex[0, 0].item(), abs=0.0001) == -4.1689
     assert pytest.approx(best_vertex[1, 0].item(), abs=0.0001) == 0.0
     assert pytest.approx(best_vertex[2, 0].item(), abs=0.0001) == 0.0
-    assert pytest.approx(torch.mm(hat_d_per_kernel_linear.t(), best_vertex), abs=0.0001) == 1.0
+    assert pytest.approx(torch.mm(hat_d_per_kernel_linear.t(), best_vertex).cpu(), abs=0.0001) == 1.0
 
 
 def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
@@ -497,7 +503,7 @@ def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
 
     # First sample is from a zero mean gaussian with unit covariance (dimension 5)
     p = MultivariateNormal(torch.zeros(5), torch.eye(5))
-    X = p.sample(
+    X_local = p.sample(
         torch.Size(
             [
                 100,
@@ -509,7 +515,7 @@ def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
     # and the second has mean 1.0 in the second coordinate
     q_1 = MultivariateNormal(torch.tensor([1.0, 0, 0, 0, 0]), torch.eye(5))
     q_2 = MultivariateNormal(torch.tensor([0, 1.0, 0, 0, 0]), torch.eye(5))
-    Y = (
+    Y_local = (
         q_1.sample(
             torch.Size(
                 [
@@ -525,23 +531,25 @@ def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
             )
         )
     ) / 2.0
-    all_h_u_per_vi_local = default_mkmmd.compute_all_h_u_linear(X, Y)
+    X_local = X_local.to(DEVICE)
+    Y_local = Y_local.to(DEVICE)
+    all_h_u_per_vi_local = default_mkmmd.compute_all_h_u_linear(X_local, Y_local)
     hat_d_per_kernel_local = default_mkmmd.compute_hat_d_per_kernel(all_h_u_per_vi_local)
-    mkmmd_before_opt = default_mkmmd(X, Y)
+    mkmmd_before_opt = default_mkmmd(X_local, Y_local)
     target_mkmmd = torch.mm(default_mkmmd.betas.t(), hat_d_per_kernel_local)[0][0]
-    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd
+    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd.cpu()
 
     hat_Q_k = default_mkmmd.compute_hat_Q_k_linear(all_h_u_per_vi_local)
-    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19)).to(DEVICE)
+    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE))
     raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
     raw_betas = torch.clamp(raw_betas, min=0)
-    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local), abs=0.0001) == 1.0000
+    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local).cpu(), abs=0.0001) == 1.0000
 
-    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    betas_local = default_mkmmd.optimize_betas(X_local, Y_local, lambda_m)
     assert torch.all(betas_local.eq((1 / torch.sum(raw_betas)) * raw_betas))
 
     default_mkmmd = MkMmdLoss(DEVICE, minimize_type_two_error=False, perform_linear_approximation=True)
-    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    betas_local = default_mkmmd.optimize_betas(X_local, Y_local, lambda_m)
     one_hot_betas = torch.zeros_like(betas_local)
 
     one_hot_betas[0, 0] = 1
@@ -555,7 +563,7 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
 
     # First sample is from a zero mean gaussian with unit covariance (dimension 5)
     p = MultivariateNormal(torch.zeros(5), torch.eye(5))
-    X = p.sample(
+    X_local = p.sample(
         torch.Size(
             [
                 100,
@@ -567,7 +575,7 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
     # and the second has mean 1.0 in the second coordinate
     q_1 = MultivariateNormal(torch.tensor([1.0, 0, 0, 0, 0]), torch.eye(5))
     q_2 = MultivariateNormal(torch.tensor([0, 1.0, 0, 0, 0]), torch.eye(5))
-    Y = (
+    Y_local = (
         q_1.sample(
             torch.Size(
                 [
@@ -583,28 +591,30 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
             )
         )
     ) / 2.0
+    X_local = X_local.to(DEVICE)
+    Y_local = Y_local.to(DEVICE)
 
-    all_h_u_per_sample = default_mkmmd.compute_all_h_u_all_samples(X, Y)
+    all_h_u_per_sample = default_mkmmd.compute_all_h_u_all_samples(X_local, Y_local)
     hat_d_per_kernel_local = default_mkmmd.compute_hat_d_per_kernel(all_h_u_per_sample)
-    mkmmd_before_opt = default_mkmmd(X, Y)
+    mkmmd_before_opt = default_mkmmd(X_local, Y_local)
     target_mkmmd = torch.mm(default_mkmmd.betas.t(), hat_d_per_kernel_local)[0][0]
-    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd
+    assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd.cpu()
 
     hat_Q_k = default_mkmmd.compute_hat_Q_k(all_h_u_per_sample, hat_d_per_kernel_local)
-    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19)).to(DEVICE)
+    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE))
     raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
     raw_betas = torch.clamp(raw_betas, min=0)
-    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local), abs=0.0001) == 1.0000
+    assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local).cpu(), abs=0.0001) == 1.0000
 
-    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    betas_local = default_mkmmd.optimize_betas(X_local, Y_local, lambda_m)
     assert torch.all(betas_local.eq((1 / torch.sum(raw_betas)) * raw_betas))
 
     default_mkmmd.betas = betas_local
-    mkmmd_after_opt = default_mkmmd(X, Y)
+    mkmmd_after_opt = default_mkmmd(X_local, Y_local)
     assert mkmmd_after_opt.item() > mkmmd_before_opt.item()
 
     default_mkmmd = MkMmdLoss(DEVICE, minimize_type_two_error=False)
-    betas_local = default_mkmmd.optimize_betas(X, Y, lambda_m)
+    betas_local = default_mkmmd.optimize_betas(X_local, Y_local, lambda_m)
     one_hot_betas = torch.zeros_like(betas_local)
 
     one_hot_betas[1, 0] = 1

--- a/tests/losses/test_mkmmd_loss.py
+++ b/tests/losses/test_mkmmd_loss.py
@@ -373,16 +373,16 @@ def test_form_kernel_samples_minus_expectation() -> None:
     kernel_samples_minus_expectation_2_0_1 = all_h_us_all[2, 0, 1] - hat_d_per_kernel_all[2, 0]
 
     assert (
-        pytest.approx(kernel_samples_minus_expectation_0_3_5.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[0, 3, 5].cpu()
+        pytest.approx(kernel_samples_minus_expectation_0_3_5.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[0, 3, 5].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_1_3_5.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[1, 3, 5].cpu()
+        pytest.approx(kernel_samples_minus_expectation_1_3_5.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[1, 3, 5].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_2_0_1.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[2, 0, 1].cpu()
+        pytest.approx(kernel_samples_minus_expectation_2_0_1.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[2, 0, 1].cpu()
     )
 
     kernel_samples_minus_expectation_0_7_2 = all_h_us_all[0, 7, 2] - hat_d_per_kernel_all[0, 0]
@@ -390,16 +390,16 @@ def test_form_kernel_samples_minus_expectation() -> None:
     kernel_samples_minus_expectation_2_1_1 = all_h_us_all[2, 1, 1] - hat_d_per_kernel_all[2, 0]
 
     assert (
-        pytest.approx(kernel_samples_minus_expectation_0_7_2.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[0, 7, 2].cpu()
+        pytest.approx(kernel_samples_minus_expectation_0_7_2.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[0, 7, 2].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_1_9_1.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[1, 9, 1].cpu()
+        pytest.approx(kernel_samples_minus_expectation_1_9_1.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[1, 9, 1].cpu()
     )
     assert (
-        pytest.approx(kernel_samples_minus_expectation_2_1_1.cpu(), abs=0.00001) 
-            == kernel_samples_minus_expectation[2, 1, 1].cpu()
+        pytest.approx(kernel_samples_minus_expectation_2_1_1.cpu(), abs=0.00001)
+        == kernel_samples_minus_expectation[2, 1, 1].cpu()
     )
 
 
@@ -540,7 +540,7 @@ def test_optimizer_betas_in_non_degenerate_case_linear() -> None:
     assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd.cpu()
 
     hat_Q_k = default_mkmmd.compute_hat_Q_k_linear(all_h_u_per_vi_local)
-    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE))
+    regularized_hat_Q_k = 2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE)
     raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
     raw_betas = torch.clamp(raw_betas, min=0)
     assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local).cpu(), abs=0.0001) == 1.0000
@@ -601,7 +601,7 @@ def test_optimizer_betas_in_non_degenerate_case() -> None:
     assert pytest.approx(mkmmd_before_opt.item(), abs=0.000001) == target_mkmmd.cpu()
 
     hat_Q_k = default_mkmmd.compute_hat_Q_k(all_h_u_per_sample, hat_d_per_kernel_local)
-    regularized_hat_Q_k = (2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE))
+    regularized_hat_Q_k = 2 * hat_Q_k + lambda_m * torch.eye(19).to(DEVICE)
     raw_betas = default_mkmmd.form_and_solve_qp(hat_d_per_kernel_local, regularized_hat_Q_k)
     raw_betas = torch.clamp(raw_betas, min=0)
     assert pytest.approx(torch.mm(raw_betas.t(), hat_d_per_kernel_local).cpu(), abs=0.0001) == 1.0000


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): [Link](https://app.clickup.com/t/868a6uduu)

The Tests for Mk-MMD loss were not properly handling device allocation if run on a GPU. This PR fixes that issue along with a small device bug in the loss function when a tensor of gammas were manually provided rather than created by default.

# Tests Added

N/A
