### PR TITLE
Move reporting start_time in servers to before fit call

### DIFF
--- a/fl4health/server/base_server.py
+++ b/fl4health/server/base_server.py
@@ -96,12 +96,17 @@ class FlServer(Server):
                 Tuple also contains the elapsed time in seconds for the round.
         """
         start_time = datetime.datetime.now()
+        self.reports_manager.report(
+            {
+                "fit_start": str(start_time),
+                "host_type": "server",
+            }
+        )
         history, elapsed_time = super().fit(num_rounds, timeout)
         end_time = datetime.datetime.now()
         self.reports_manager.report(
             {
                 "fit_elapsed_time": str(start_time - end_time),
-                "fit_start": str(start_time),
                 "fit_end": str(end_time),
                 "num_rounds": num_rounds,
                 "host_type": "server",
@@ -438,12 +443,17 @@ class FlServerWithCheckpointing(FlServer, Generic[ExchangerType]):
         """
         if self.per_round_checkpointer is not None:
             start_time = datetime.datetime.now()
+            self.reports_manager.report(
+                {
+                    "fit_start": str(start_time),
+                    "host_type": "server",
+                }
+            )
             history, elapsed_time = self.fit_with_per_epoch_checkpointing(num_rounds, timeout)
             end_time = datetime.datetime.now()
             self.reports_manager.report(
                 {
                     "fit_elapsed_time": str(start_time - end_time),
-                    "fit_start": str(start_time),
                     "fit_end": str(end_time),
                     "num_rounds": num_rounds,
                     "host_type": "server",

--- a/fl4health/server/evaluate_server.py
+++ b/fl4health/server/evaluate_server.py
@@ -97,6 +97,14 @@ class EvaluateServer(Server):
         # Run Federated Evaluation
         log(INFO, "Federated Evaluation Starting")
         start_time = datetime.datetime.now()
+
+        for reporter in self.reporters:
+            reporter.report(
+                {
+                    "fit_start": str(start_time),
+                    "host_type": "server",
+                }
+            )
         # We're only performing federated evaluation. So we make use of the evaluate round function, but simply
         # perform such evaluation once.
         res_fed = self.federated_evaluate(timeout=timeout)
@@ -106,7 +114,6 @@ class EvaluateServer(Server):
             r.report(
                 {
                     "fit_elapsed_time": str(start_time - end_time),
-                    "fit_start": str(start_time),
                     "fit_end": str(end_time),
                     "num_rounds": num_rounds,
                     "host_type": "server",


### PR DESCRIPTION
# PR Type
[Feature | **Fix** | Documentation | Other ]

# Short Description

Had to move reporting of start time in servers to before fit call because FLorist has a custom RedisReporter that we listen to for updates that are time sensitive (ie if we don't get fit start after a certain amount of time, we timeout.)
