### PR TITLE
Lowercasing torch device variables throughout library when not global

### DIFF
--- a/examples/ae_examples/cvae_dim_example/client.py
+++ b/examples/ae_examples/cvae_dim_example/client.py
@@ -22,8 +22,8 @@ from fl4health.utils.sampler import DirichletLabelBasedSampler
 
 
 class CvaeDimClient(BasicClient):
-    def __init__(self, data_path: Path, metrics: Sequence[Metric], DEVICE: torch.device, condition: torch.Tensor):
-        super().__init__(data_path, metrics, DEVICE)
+    def __init__(self, data_path: Path, metrics: Sequence[Metric], device: torch.device, condition: torch.Tensor):
+        super().__init__(data_path, metrics, device)
         self.condition = condition
 
     def get_data_loaders(self, config: Config) -> Tuple[DataLoader, DataLoader]:
@@ -64,11 +64,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     set_all_random_seeds(42)
     # Creating the condition vector used for training this CVAE.
     condition_vector = torch.nn.functional.one_hot(torch.tensor(args.condition), num_classes=args.num_conditions)
-    client = CvaeDimClient(data_path, [Accuracy("accuracy")], DEVICE, condition_vector)
+    client = CvaeDimClient(data_path, [Accuracy("accuracy")], device, condition_vector)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/ae_examples/cvae_examples/conv_cvae_example/client.py
+++ b/examples/ae_examples/cvae_examples/conv_cvae_example/client.py
@@ -36,8 +36,8 @@ def binary_class_condition_data_converter(
 
 
 class CondConvAutoEncoderClient(BasicClient):
-    def __init__(self, data_path: Path, metrics: Sequence[Metric], DEVICE: torch.device) -> None:
-        super().__init__(data_path, metrics, DEVICE)
+    def __init__(self, data_path: Path, metrics: Sequence[Metric], device: torch.device) -> None:
+        super().__init__(data_path, metrics, device)
         # To train an autoencoder-based model we need to define a data converter that prepares the data
         # for self-supervised learning, concatenates the inputs and condition (packing) to let the data
         # fit into the training pipeline, and unpacks the input from condition for the model inference.
@@ -93,8 +93,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
     set_all_random_seeds(42)
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CondConvAutoEncoderClient(data_path=data_path, metrics=[], DEVICE=DEVICE)
+    client = CondConvAutoEncoderClient(data_path=data_path, metrics=[], device=device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/ae_examples/cvae_examples/mlp_cvae_example/client.py
+++ b/examples/ae_examples/cvae_examples/mlp_cvae_example/client.py
@@ -25,9 +25,9 @@ from fl4health.utils.sampler import DirichletLabelBasedSampler
 
 class CondAutoEncoderClient(BasicClient):
     def __init__(
-        self, data_path: Path, metrics: Sequence[Metric], DEVICE: torch.device, condition: torch.Tensor
+        self, data_path: Path, metrics: Sequence[Metric], device: torch.device, condition: torch.Tensor
     ) -> None:
-        super().__init__(data_path, metrics, DEVICE)
+        super().__init__(data_path, metrics, device)
         # In this example, condition is based on client ID.
         self.condition_vector = condition
         # To train an autoencoder-based model we need to define a data converter that prepares the data
@@ -96,13 +96,13 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     set_all_random_seeds(42)
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     # Create the condition vector. This creation needs to be "consistent" across clients.
     # In this example, condition is based on client ID.
     # Client should decide how they want to create their condition vector.
     # Here we use simple one_hot_encoding but it can be any vector.
     condition_vector = torch.nn.functional.one_hot(torch.tensor(args.condition), num_classes=args.num_conditions)
-    client = CondAutoEncoderClient(data_path, [], DEVICE, condition_vector)
+    client = CondAutoEncoderClient(data_path, [], device, condition_vector)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/ae_examples/fedprox_vae_example/client.py
+++ b/examples/ae_examples/fedprox_vae_example/client.py
@@ -60,8 +60,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = VaeFedProxClient(data_path, [], DEVICE)
+    client = VaeFedProxClient(data_path, [], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/apfl_example/client.py
+++ b/examples/apfl_example/client.py
@@ -53,12 +53,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistApflClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistApflClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()  # This will tell the JsonReporter to dump data

--- a/examples/basic_example/client.py
+++ b/examples/basic_example/client.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = CifarClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/ditto_example/client.py
+++ b/examples/ditto_example/client.py
@@ -61,15 +61,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistDittoClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistDittoClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
     fl.client.start_client(server_address=args.server_address, client=client.to_client())
 
     # Shutdown the client gracefully

--- a/examples/docker_basic_example/fl_client/client.py
+++ b/examples/docker_basic_example/fl_client/client.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Load model and data
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = CifarClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="fl_server:8080", client=client.to_client())

--- a/examples/dp_fed_examples/client_level_dp/client.py
+++ b/examples/dp_fed_examples/client_level_dp/client.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     # Load model and data
     data_path = Path(args.dataset_path)
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    client = CifarClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/dp_fed_examples/client_level_dp_weighted/client.py
+++ b/examples/dp_fed_examples/client_level_dp_weighted/client.py
@@ -40,8 +40,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Load model and data
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = HospitalClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = HospitalClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/dp_fed_examples/instance_level_dp/client.py
+++ b/examples/dp_fed_examples/instance_level_dp/client.py
@@ -52,8 +52,8 @@ if __name__ == "__main__":
 
     # Load model and data
     data_path = Path(args.dataset_path)
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE, checkpointer=checkpointer)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    client = CifarClient(data_path, [Accuracy("accuracy")], device, checkpointer=checkpointer)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
 
     client.shutdown()

--- a/examples/dp_scaffold_example/client.py
+++ b/examples/dp_scaffold_example/client.py
@@ -41,10 +41,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
-    client = MnistDPScaffoldClient(data_path=data_path, metrics=[Accuracy()], device=DEVICE)
+    client = MnistDPScaffoldClient(data_path=data_path, metrics=[Accuracy()], device=device)
 
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/dynamic_layer_exchange_example/client.py
+++ b/examples/dynamic_layer_exchange_example/client.py
@@ -67,8 +67,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarDynamicLayerClient(data_path, [Accuracy("accuracy")], DEVICE, store_initial_model=True)
+    client = CifarDynamicLayerClient(data_path, [Accuracy("accuracy")], device, store_initial_model=True)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/ensemble_example/client.py
+++ b/examples/ensemble_example/client.py
@@ -52,8 +52,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
-    client = MnistEnsembleClient(data_path, [Accuracy()], DEVICE)
+    client = MnistEnsembleClient(data_path, [Accuracy()], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())

--- a/examples/feature_alignment_example/client.py
+++ b/examples/feature_alignment_example/client.py
@@ -90,15 +90,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     data_path = Path(args.dataset_path)
 
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # ham_id is the id column and LOSgroupNum is the target column.
-    client = Mimic3TabularDataClient(data_path, [Accuracy("accuracy")], DEVICE, "hadm_id", ["LOSgroupNum"])
+    client = Mimic3TabularDataClient(data_path, [Accuracy("accuracy")], device, "hadm_id", ["LOSgroupNum"])
     # This call demonstrates how the user may specify a particular sklearn pipeline for a specific feature.
     client.preset_specific_pipeline("NumNotes", MaxAbsScaler())
     fl.client.start_client(server_address=args.server_address, client=client.to_client())

--- a/examples/fedbn_example/client.py
+++ b/examples/fedbn_example/client.py
@@ -88,15 +88,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     if args.dataset_name in ["Barcelona", "Rosendahl", "Vienna", "UFES", "Canada"]:
-        client: BasicClient = SkinCancerFedBNClient(data_path, [Accuracy()], DEVICE, args.dataset_name)
+        client: BasicClient = SkinCancerFedBNClient(data_path, [Accuracy()], device, args.dataset_name)
     elif args.dataset_name == "mnist":
-        client = MnistFedBNClient(data_path, [Accuracy()], DEVICE)
+        client = MnistFedBNClient(data_path, [Accuracy()], device)
     else:
         raise ValueError(
             "Unsupported dataset name. Please choose from 'Barcelona', 'Rosendahl', \

--- a/examples/feddg_ga_example/client.py
+++ b/examples/feddg_ga_example/client.py
@@ -53,12 +53,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistApflClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistApflClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/federated_eval_example/client.py
+++ b/examples/federated_eval_example/client.py
@@ -63,12 +63,12 @@ if __name__ == "__main__":
     data_path = Path(args.dataset_path)
     client_checkpoint_path = Path(args.checkpoint_path) if args.checkpoint_path else None
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     client = CifarClient(
         data_path=data_path,
         metrics=[Accuracy("accuracy")],
-        device=DEVICE,
+        device=device,
         model_checkpoint_path=client_checkpoint_path,
     )
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())

--- a/examples/fedopt_example/client.py
+++ b/examples/fedopt_example/client.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Load model and data
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = NewsClassifierClient(data_path, [CompoundMetric("Compound Metric")], DEVICE)
+    client = NewsClassifierClient(data_path, [CompoundMetric("Compound Metric")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())

--- a/examples/fedpca_examples/dim_reduction/client.py
+++ b/examples/fedpca_examples/dim_reduction/client.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     parser.add_argument("--seed", action="store", type=int, help="Random seed for this client.")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     seed = args.seed
 
@@ -74,6 +74,6 @@ if __name__ == "__main__":
     # the data used in the perform_pca example, then both examples
     # should use the same random seed.
     set_all_random_seeds(seed)
-    client = MnistFedPcaClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = MnistFedPcaClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fedpca_examples/perform_pca/client.py
+++ b/examples/fedpca_examples/perform_pca/client.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     parser.add_argument("--seed", action="store", type=int, help="Random seed for this client.")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     components_save_path = Path(args.components_save_path)
     seed = args.seed
@@ -45,5 +45,5 @@ if __name__ == "__main__":
     # the data used in the dim_reduction example, then both examples
     # should use the same random seed.
     set_all_random_seeds(seed)
-    client = MnistFedPCAClient(data_path=data_path, device=DEVICE, model_save_path=components_save_path)
+    client = MnistFedPCAClient(data_path=data_path, device=device, model_save_path=components_save_path)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())

--- a/examples/fedper_example/client.py
+++ b/examples/fedper_example/client.py
@@ -62,9 +62,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     minority_numbers = {int(number) for number in args.minority_numbers}
-    client = MnistFedPerClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    client = MnistFedPerClient(data_path, [Accuracy("accuracy")], device, minority_numbers)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fedpm_example/client.py
+++ b/examples/fedpm_example/client.py
@@ -54,9 +54,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     minority_numbers = {int(number) for number in args.minority_numbers}
-    client = MnistFedPmClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    client = MnistFedPmClient(data_path, [Accuracy("accuracy")], device, minority_numbers)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fedprox_example/client.py
+++ b/examples/fedprox_example/client.py
@@ -57,15 +57,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistFedProxClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistFedProxClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
     fl.client.start_client(server_address=args.server_address, client=client.to_client())
 
     # Shutdown the client gracefully

--- a/examples/fedrep_example/client.py
+++ b/examples/fedrep_example/client.py
@@ -55,8 +55,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_dir = Path(args.dataset_path)
-    client = CifarFedRepClient(data_dir, [Accuracy("accuracy")], DEVICE)
+    client = CifarFedRepClient(data_dir, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fedsimclr_example/fedsimclr_finetuning_example/client.py
+++ b/examples/fedsimclr_example/fedsimclr_finetuning_example/client.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = CifarClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fedsimclr_example/fedsimclr_pretraining_example/client.py
+++ b/examples/fedsimclr_example/fedsimclr_pretraining_example/client.py
@@ -91,8 +91,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = SslCifarClient(data_path, [], DEVICE)
+    client = SslCifarClient(data_path, [], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fenda_ditto_example/client.py
+++ b/examples/fenda_ditto_example/client.py
@@ -94,9 +94,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     client = MnistFendaDittoClient(
         data_path,
         [Accuracy()],
-        DEVICE,
+        device,
         args.checkpoint_path,
         checkpointer=checkpointer,
         reporters=[JsonReporter()],

--- a/examples/fenda_example/client.py
+++ b/examples/fenda_example/client.py
@@ -59,9 +59,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     minority_numbers = {int(number) for number in args.minority_numbers}
-    client = MnistFendaClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    client = MnistFendaClient(data_path, [Accuracy("accuracy")], device, minority_numbers)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/fl_plus_local_ft_example/client.py
+++ b/examples/fl_plus_local_ft_example/client.py
@@ -40,10 +40,10 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     metrics = [Accuracy("accuracy")]
-    client = CifarClient(data_path, metrics, DEVICE)
+    client = CifarClient(data_path, metrics, device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
 
     # Run further local training after the federated learning has finished

--- a/examples/flash_example/client.py
+++ b/examples/flash_example/client.py
@@ -40,8 +40,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarFlashClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = CifarFlashClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/moon_example/client.py
+++ b/examples/moon_example/client.py
@@ -57,9 +57,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     minority_numbers = {int(number) for number in args.minority_numbers}
-    client = MnistMoonClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    client = MnistMoonClient(data_path, [Accuracy("accuracy")], device, minority_numbers)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/mr_mtl_example/client.py
+++ b/examples/mr_mtl_example/client.py
@@ -57,15 +57,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistMrMtlClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistMrMtlClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
 
     fl.client.start_client(server_address=args.server_address, client=client.to_client())
 

--- a/examples/nnunet_example/client.py
+++ b/examples/nnunet_example/client.py
@@ -37,8 +37,8 @@ def main(
     client_name: Optional[str] = None,
 ) -> None:
     # Log device and server address
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Using device: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Using device: {device}")
     log(INFO, f"Using server address: {server_address}")
 
     # Load the dataset if necessary
@@ -63,7 +63,7 @@ def main(
             name="Pseudo DICE",
             metric=GeneralizedDiceScore(
                 num_classes=msd_num_labels[msd_dataset_enum], weight_type="square", include_background=False
-            ).to(DEVICE),
+            ).to(device),
         ),
         pred_transforms=[torch.sigmoid, get_segs_from_probs],
     )
@@ -77,7 +77,7 @@ def main(
         verbose=verbose,
         compile=compile,
         # BaseClient Args
-        device=DEVICE,
+        device=device,
         metrics=[dice],
         progress_bar=verbose,
         intermediate_client_state_dir=(

--- a/examples/perfcl_example/client.py
+++ b/examples/perfcl_example/client.py
@@ -65,9 +65,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     minority_numbers = {int(number) for number in args.minority_numbers}
-    client = MnistPerFclClient(data_path, [Accuracy("accuracy")], DEVICE, minority_numbers)
+    client = MnistPerFclClient(data_path, [Accuracy("accuracy")], device, minority_numbers)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/scaffold_example/client.py
+++ b/examples/scaffold_example/client.py
@@ -50,12 +50,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
-    client = MnistScaffoldClient(data_path, [Accuracy()], DEVICE, reporters=[JsonReporter()])
+    client = MnistScaffoldClient(data_path, [Accuracy()], device, reporters=[JsonReporter()])
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/sparse_tensor_partial_exchange_example/client.py
+++ b/examples/sparse_tensor_partial_exchange_example/client.py
@@ -51,8 +51,8 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    client = CifarSparseCooTensorClient(data_path, [Accuracy("accuracy")], DEVICE)
+    client = CifarSparseCooTensorClient(data_path, [Accuracy("accuracy")], device)
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/examples/warm_up_example/fedavg_warm_up/client.py
+++ b/examples/warm_up_example/fedavg_warm_up/client.py
@@ -84,16 +84,16 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
     set_all_random_seeds(args.seed)
 
     # Start the client
-    client = MnistFedAvgClient(data_path, [Accuracy()], DEVICE, checkpoint_dir=args.checkpoint_dir)
+    client = MnistFedAvgClient(data_path, [Accuracy()], device, checkpoint_dir=args.checkpoint_dir)
     fl.client.start_client(server_address=args.server_address, client=client.to_client())
 
     # Shutdown the client gracefully

--- a/examples/warm_up_example/warmed_up_fedprox/client.py
+++ b/examples/warm_up_example/warmed_up_fedprox/client.py
@@ -100,11 +100,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     pretrained_model_dir = Path(args.pretrained_model_dir)
     weights_mapping_path = Path(args.weights_mapping_path) if args.weights_mapping_path else None
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     client = MnistFedProxClient(
         data_path,
         [Accuracy()],
-        DEVICE,
+        device,
         pretrained_model_dir,
         weights_mapping_path,
     )

--- a/examples/warm_up_example/warmed_up_fenda/client.py
+++ b/examples/warm_up_example/warmed_up_fenda/client.py
@@ -103,11 +103,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     pretrained_model_dir = Path(args.pretrained_model_dir)
     weights_mapping_path = Path(args.weights_mapping_path) if args.weights_mapping_path else None
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     # Set the random seed for reproducibility
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     client = MnistFendaClient(
         data_path,
         [Accuracy("accuracy")],
-        DEVICE,
+        device,
         pretrained_model_dir,
         weights_mapping_path,
     )

--- a/research/ag_news/dynamic_layer_exchange/client.py
+++ b/research/ag_news/dynamic_layer_exchange/client.py
@@ -168,11 +168,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     data_path = Path(args.dataset_dir)
 
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Exchange Percentage: {args.exchange_percentage}")
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     client = BertDynamicLayerExchangeClient(
         data_path,
         [Accuracy("accuracy")],
-        DEVICE,
+        device,
         learning_rate=args.learning_rate,
         exchange_percentage=args.exchange_percentage,
         norm_threshold=args.norm_threshold,

--- a/research/ag_news/sparse_tensor_exchange/client.py
+++ b/research/ag_news/sparse_tensor_exchange/client.py
@@ -137,11 +137,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     data_path = Path(args.dataset_dir)
 
-    log(INFO, f"Device to be used: {DEVICE}")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Sparsity Level: {args.sparsity_level}")
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     client = BertSparseTensorExchangeClient(
         data_path,
         [Accuracy("accuracy")],
-        DEVICE,
+        device,
         learning_rate=args.learning_rate,
         sparsity_level=args.sparsity_level,
         checkpointer=checkpointer,

--- a/research/cifar10/adaptive_pfl/ditto/client.py
+++ b/research/cifar10/adaptive_pfl/ditto/client.py
@@ -123,8 +123,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -157,7 +157,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/adaptive_pfl/fedprox/client.py
+++ b/research/cifar10/adaptive_pfl/fedprox/client.py
@@ -127,8 +127,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -161,7 +161,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/adaptive_pfl/fenda_ditto/client.py
+++ b/research/cifar10/adaptive_pfl/fenda_ditto/client.py
@@ -135,8 +135,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -171,7 +171,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/adaptive_pfl/mrmtl/client.py
+++ b/research/cifar10/adaptive_pfl/mrmtl/client.py
@@ -121,8 +121,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -155,7 +155,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/ditto/client.py
+++ b/research/cifar10/ditto/client.py
@@ -184,8 +184,8 @@ if __name__ == "__main__":
     if args.use_partitioned_data:
         log(INFO, "Using preprocessed partitioned data for training, validation and testing")
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     client = CifarDittoClient(
         data_path=data_path,
         metrics=[Accuracy("accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/ditto_deep_mmd/client.py
+++ b/research/cifar10/ditto_deep_mmd/client.py
@@ -210,8 +210,8 @@ if __name__ == "__main__":
     if args.use_partitioned_data:
         log(INFO, "Using preprocessed partitioned data for training, validation and testing")
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Mu: {args.mu}")
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     client = CifarDittoClient(
         data_path=data_path,
         metrics=[Accuracy("accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/ditto_mkmmd/client.py
+++ b/research/cifar10/ditto_mkmmd/client.py
@@ -226,8 +226,8 @@ if __name__ == "__main__":
     if args.use_partitioned_data:
         log(INFO, "Using preprocessed partitioned data for training, validation and testing")
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Mu: {args.mu}")
@@ -259,7 +259,7 @@ if __name__ == "__main__":
     client = CifarDittoClient(
         data_path=data_path,
         metrics=[Accuracy("accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/fed_dgga_pfl/ditto/client.py
+++ b/research/cifar10/fed_dgga_pfl/ditto/client.py
@@ -123,8 +123,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -157,7 +157,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/fed_dgga_pfl/fenda/client.py
+++ b/research/cifar10/fed_dgga_pfl/fenda/client.py
@@ -121,8 +121,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -155,7 +155,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/fed_dgga_pfl/fenda_ditto/client.py
+++ b/research/cifar10/fed_dgga_pfl/fenda_ditto/client.py
@@ -135,8 +135,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Beta: {args.beta}")
@@ -171,7 +171,7 @@ if __name__ == "__main__":
             F1("f1_score_macro", average="macro"),
             F1("f1_score_weight", average="weighted"),
         ],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/cifar10/fedavg/client.py
+++ b/research/cifar10/fedavg/client.py
@@ -184,8 +184,8 @@ if __name__ == "__main__":
     if args.use_partitioned_data:
         log(INFO, "Using preprocessed partitioned data for training, validation and testing")
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -213,7 +213,7 @@ if __name__ == "__main__":
     client = CifarFedAvgClient(
         data_path=data_path,
         metrics=[Accuracy("accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         heterogeneity_level=args.beta,

--- a/research/flamby/fed_heart_disease/apfl/client.py
+++ b/research/flamby/fed_heart_disease/apfl/client.py
@@ -117,8 +117,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Alpha Learning Rate: {args.alpha_learning_rate}")
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseApflClient(
         data_path=args.dataset_dir,
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         alpha_learning_rate=args.alpha_learning_rate,

--- a/research/flamby/fed_heart_disease/central/train.py
+++ b/research/flamby/fed_heart_disease/central/train.py
@@ -61,11 +61,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedHeartDiseaseCentralizedTrainer(
-        DEVICE,
+        device,
         args.artifact_dir,
         args.dataset_dir,
         args.run_name,

--- a/research/flamby/fed_heart_disease/ditto/client.py
+++ b/research/flamby/fed_heart_disease/ditto/client.py
@@ -123,8 +123,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseDittoClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/fedadam/client.py
+++ b/research/flamby/fed_heart_disease/fedadam/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseFedAdamClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/fedavg/client.py
+++ b/research/flamby/fed_heart_disease/fedavg/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseFedAvgClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/fedper/client.py
+++ b/research/flamby/fed_heart_disease/fedper/client.py
@@ -127,8 +127,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseFedPerClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/fedprox/client.py
+++ b/research/flamby/fed_heart_disease/fedprox/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseFedProxClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/fenda/client.py
+++ b/research/flamby/fed_heart_disease/fenda/client.py
@@ -120,8 +120,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseFendaClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/local/train.py
+++ b/research/flamby/fed_heart_disease/local/train.py
@@ -67,11 +67,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedHeartDiseaseLocalTrainer(
-        DEVICE,
+        device,
         args.client_number,
         args.artifact_dir,
         args.dataset_dir,

--- a/research/flamby/fed_heart_disease/moon/client.py
+++ b/research/flamby/fed_heart_disease/moon/client.py
@@ -124,8 +124,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseMoonClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/perfcl/client.py
+++ b/research/flamby/fed_heart_disease/perfcl/client.py
@@ -138,8 +138,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     client = FedHeartDiseasePerFclClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_heart_disease/scaffold/client.py
+++ b/research/flamby/fed_heart_disease/scaffold/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedHeartDiseaseScaffoldClient(
         data_path=Path(args.dataset_dir),
         metrics=[Accuracy("FedHeartDisease_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/apfl/client.py
+++ b/research/flamby/fed_isic2019/apfl/client.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Alpha Learning Rate: {args.alpha_learning_rate}")
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     client = FedIsic2019ApflClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         alpha_learning_rate=args.alpha_learning_rate,

--- a/research/flamby/fed_isic2019/central/train.py
+++ b/research/flamby/fed_isic2019/central/train.py
@@ -60,11 +60,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedIsic2019CentralizedTrainer(
-        DEVICE,
+        device,
         args.artifact_dir,
         args.dataset_dir,
         args.run_name,

--- a/research/flamby/fed_isic2019/ditto/client.py
+++ b/research/flamby/fed_isic2019/ditto/client.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     client = FedIsic2019DittoClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/ditto_deep_mmd/client.py
+++ b/research/flamby/fed_isic2019/ditto_deep_mmd/client.py
@@ -146,8 +146,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Mu: {args.mu}")
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     client = FedIsic2019DittoClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/ditto_mkmmd/client.py
+++ b/research/flamby/fed_isic2019/ditto_mkmmd/client.py
@@ -161,8 +161,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Mu: {args.mu}")
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     client = FedIsic2019DittoClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/fedadam/client.py
+++ b/research/flamby/fed_isic2019/fedadam/client.py
@@ -107,8 +107,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     client = FedIsic2019FedAdamClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/fedavg/client.py
+++ b/research/flamby/fed_isic2019/fedavg/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedIsic2019FedAvgClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/fedper/client.py
+++ b/research/flamby/fed_isic2019/fedper/client.py
@@ -122,8 +122,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     client = FedIsic2019FedPerClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/fedprox/client.py
+++ b/research/flamby/fed_isic2019/fedprox/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedIsic2019FedProxClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/fenda/client.py
+++ b/research/flamby/fed_isic2019/fenda/client.py
@@ -120,8 +120,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     client = FedIsic2019FendaClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/local/train.py
+++ b/research/flamby/fed_isic2019/local/train.py
@@ -67,11 +67,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedIsic2019LocalTrainer(
-        DEVICE,
+        device,
         args.client_number,
         args.artifact_dir,
         args.dataset_dir,

--- a/research/flamby/fed_isic2019/moon/client.py
+++ b/research/flamby/fed_isic2019/moon/client.py
@@ -124,8 +124,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     client = FedIsic2019MoonClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/mr_mtl_mkmmd/client.py
+++ b/research/flamby/fed_isic2019/mr_mtl_mkmmd/client.py
@@ -157,8 +157,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Mu: {args.mu}")
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     client = FedIsic2019MrMtlClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/perfcl/client.py
+++ b/research/flamby/fed_isic2019/perfcl/client.py
@@ -138,8 +138,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     client = FedIsic2019PerFclClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_isic2019/scaffold/client.py
+++ b/research/flamby/fed_isic2019/scaffold/client.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     client = FedIsic2019ScaffoldClient(
         data_path=Path(args.dataset_dir),
         metrics=[BalancedAccuracy("FedIsic2019_balanced_accuracy")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/apfl/client.py
+++ b/research/flamby/fed_ixi/apfl/client.py
@@ -119,8 +119,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Alpha Learning Rate: {args.alpha_learning_rate}")
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     client = FedIxiApflClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         alpha_learning_rate=args.alpha_learning_rate,

--- a/research/flamby/fed_ixi/central/train.py
+++ b/research/flamby/fed_ixi/central/train.py
@@ -64,11 +64,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedIxiCentralizedTrainer(
-        DEVICE,
+        device,
         args.artifact_dir,
         args.dataset_dir,
         args.run_name,

--- a/research/flamby/fed_ixi/ditto/client.py
+++ b/research/flamby/fed_ixi/ditto/client.py
@@ -126,8 +126,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     client = FedIxiDittoClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/fedadam/client.py
+++ b/research/flamby/fed_ixi/fedadam/client.py
@@ -107,8 +107,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     client = FedIxiFedAdamClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/fedavg/client.py
+++ b/research/flamby/fed_ixi/fedavg/client.py
@@ -109,8 +109,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     client = FedIxiFedAvgClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/fedper/client.py
+++ b/research/flamby/fed_ixi/fedper/client.py
@@ -127,8 +127,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     client = FedIxiFedPerClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/fedprox/client.py
+++ b/research/flamby/fed_ixi/fedprox/client.py
@@ -109,8 +109,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     client = FedIxiFedProxClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/fenda/client.py
+++ b/research/flamby/fed_ixi/fenda/client.py
@@ -120,8 +120,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     client = FedIxiFendaClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/local/train.py
+++ b/research/flamby/fed_ixi/local/train.py
@@ -71,11 +71,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
 
     trainer = FedIxiLocalTrainer(
-        DEVICE,
+        device,
         args.client_number,
         args.artifact_dir,
         args.dataset_dir,

--- a/research/flamby/fed_ixi/moon/client.py
+++ b/research/flamby/fed_ixi/moon/client.py
@@ -124,8 +124,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     client = FedIxiMoonClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/perfcl/client.py
+++ b/research/flamby/fed_ixi/perfcl/client.py
@@ -138,8 +138,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
     log(INFO, f"Performing Federated Checkpointing: {not args.no_federated_checkpointing}")
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     client = FedIxiPerFclClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/flamby/fed_ixi/scaffold/client.py
+++ b/research/flamby/fed_ixi/scaffold/client.py
@@ -109,8 +109,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
     log(INFO, f"Learning Rate: {args.learning_rate}")
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     client = FedIxiScaffoldClient(
         data_path=Path(args.dataset_dir),
         metrics=[BinarySoftDiceCoefficient("FedIXI_dice")],
-        device=DEVICE,
+        device=device,
         client_number=args.client_number,
         learning_rate=args.learning_rate,
         checkpointer=checkpointer,

--- a/research/gemini/apfl/client.py
+++ b/research/gemini/apfl/client.py
@@ -277,8 +277,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -286,7 +286,7 @@ if __name__ == "__main__":
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.alpha_learning_rate,

--- a/research/gemini/central/train.py
+++ b/research/gemini/central/train.py
@@ -121,14 +121,14 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
 
     main(
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        DEVICE,
+        device,
         args.task,
         args.batch_size,
         args.num_epochs,

--- a/research/gemini/ditto/client.py
+++ b/research/gemini/ditto/client.py
@@ -154,8 +154,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     client = GeminiDittoClient(
         data_path=data_path,
         metrics=[Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        device=DEVICE,
+        device=device,
         hospital_id=args.hospital_id,
         learning_rate=args.learning_rate,
         learning_task=args.task,

--- a/research/gemini/fedavg/client.py
+++ b/research/gemini/fedavg/client.py
@@ -185,8 +185,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -194,7 +194,7 @@ if __name__ == "__main__":
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.artifact_dir,

--- a/research/gemini/fedopt/client.py
+++ b/research/gemini/fedopt/client.py
@@ -191,8 +191,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -200,7 +200,7 @@ if __name__ == "__main__":
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.artifact_dir,

--- a/research/gemini/fedper/client.py
+++ b/research/gemini/fedper/client.py
@@ -151,8 +151,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -161,7 +161,7 @@ if __name__ == "__main__":
     client = GeminiFedPerClient(
         data_path=data_path,
         metrics=[Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        device=DEVICE,
+        device=device,
         hospital_id=args.hospital_id,
         learning_rate=args.learning_rate,
         learning_task=args.task,

--- a/research/gemini/fedprox/client.py
+++ b/research/gemini/fedprox/client.py
@@ -144,15 +144,15 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
     client = GeminiFedProxClient(
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.mu,

--- a/research/gemini/fenda/client.py
+++ b/research/gemini/fenda/client.py
@@ -199,8 +199,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -208,7 +208,7 @@ if __name__ == "__main__":
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.artifact_dir,

--- a/research/gemini/local/train.py
+++ b/research/gemini/local/train.py
@@ -125,14 +125,14 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
 
     main(
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        DEVICE,
+        device,
         args.hospital_id,
         args.task,
         args.batch_size,

--- a/research/gemini/moon/client.py
+++ b/research/gemini/moon/client.py
@@ -155,8 +155,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     client = GeminiMoonClient(
         data_path=data_path,
         metrics=[Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        device=DEVICE,
+        device=device,
         hospital_id=args.hospital_id,
         learning_rate=args.learning_rate,
         learning_task=args.task,

--- a/research/gemini/perfcl/client.py
+++ b/research/gemini/perfcl/client.py
@@ -163,8 +163,8 @@ if __name__ == "__main__":
         # change based on the location of data
         data_path = Path("heterogeneous_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     client = GeminiPerFclClient(
         data_path=data_path,
         metrics=[Binary_ROC_AUC(), Binary_F1(), Accuracy()],
-        device=DEVICE,
+        device=device,
         hospital_id=args.hospital_id,
         learning_rate=args.learning_rate,
         learning_task=args.task,

--- a/research/gemini/scaffold/client.py
+++ b/research/gemini/scaffold/client.py
@@ -259,8 +259,8 @@ if __name__ == "__main__":
     elif args.task == "delirium":
         data_path = Path("delirium_data")
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Task: {args.task}")
     log(INFO, f"Server Address: {args.server_address}")
 
@@ -268,7 +268,7 @@ if __name__ == "__main__":
         data_path,
         [Binary_ROC_AUC(), Binary_F1(), Accuracy()],
         args.hospital_id,
-        DEVICE,
+        device,
         args.task,
         args.learning_rate,
         args.artifact_dir,

--- a/research/picai/fedavg/client.py
+++ b/research/picai/fedavg/client.py
@@ -150,21 +150,21 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Device to be used: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Device to be used: {device}")
     log(INFO, f"Server Address: {args.server_address}")
 
     metrics = [
         TorchMetric(
             name="MLAP",
-            metric=MultilabelAveragePrecision(average="macro", num_labels=2, thresholds=3).to(DEVICE),
+            metric=MultilabelAveragePrecision(average="macro", num_labels=2, thresholds=3).to(device),
         )
     ]
 
     client = PicaiFedAvgClient(
         data_path=Path(args.base_dir),
         metrics=metrics,
-        device=DEVICE,
+        device=device,
         intermediate_client_state_dir=args.artifact_dir,
         overviews_dir=args.overviews_dir,
         data_partition=args.data_partition,

--- a/research/picai/fl_nnunet/start_client.py
+++ b/research/picai/fl_nnunet/start_client.py
@@ -37,21 +37,21 @@ def main(
 ) -> None:
 
     # Log device and server address
-    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log(INFO, f"Using device: {DEVICE}")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log(INFO, f"Using device: {device}")
     log(INFO, f"Using server address: {server_address}")
 
     # Define metrics
     dice1 = TransformsMetric(
         metric=TorchMetric(
             name="dice1",
-            metric=GeneralizedDiceScore(num_classes=2, weight_type="square", include_background=False).to(DEVICE),
+            metric=GeneralizedDiceScore(num_classes=2, weight_type="square", include_background=False).to(device),
         ),
         pred_transforms=[torch.sigmoid, get_segs_from_probs],
     )
     # The Dice class requires preds to be ohe, but targets to not be ohe
     dice2 = TransformsMetric(
-        metric=TorchMetric(name="dice2", metric=Dice(num_classes=2, ignore_index=0).to(DEVICE)),
+        metric=TorchMetric(name="dice2", metric=Dice(num_classes=2, ignore_index=0).to(device)),
         pred_transforms=[torch.sigmoid],
         target_transforms=[partial(collapse_one_hot_tensor, dim=1)],
     )
@@ -69,7 +69,7 @@ def main(
         verbose=verbose,
         compile=compile,
         # BaseClient Args
-        device=DEVICE,
+        device=device,
         metrics=metrics,
         progress_bar=verbose,
         intermediate_client_state_dir=(

--- a/research/picai/reporting/client.py
+++ b/research/picai/reporting/client.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     parser.add_argument("--dataset_path", action="store", type=str, help="Path to the local dataset")
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
     reporter = WandBReporter(
         wandb_step_type="step",
@@ -57,6 +57,6 @@ if __name__ == "__main__":
         job_type="client",
     )
     # reporter = JsonReporter()
-    client = CifarClient(data_path, [Accuracy("accuracy")], DEVICE, reporters=[reporter])
+    client = CifarClient(data_path, [Accuracy("accuracy")], device, reporters=[reporter])
     fl.client.start_client(server_address="0.0.0.0:8080", client=client.to_client())
     client.shutdown()

--- a/tests/smoke_tests/load_from_checkpoint_example/client.py
+++ b/tests/smoke_tests/load_from_checkpoint_example/client.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)
 
     # Set the random seed for reproducibility
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     client = CifarClient(
         data_path,
         [Accuracy("accuracy")],
-        DEVICE,
+        device,
         intermediate_client_state_dir=args.intermediate_client_state_dir,
         client_name=args.client_name,
         seed=args.seed,


### PR DESCRIPTION
# PR Type
Other

# Short Description

Clickup Ticket(s): N/A

Just a small syntax cleanup PR that lowercases the torch device variable in the library throughout when it isn't being used as a global variable. This is a bit more standard practice.

# Tests Added

N/A. This is strictly a name change. So shouldn't change functionality.
