### PR TITLE
Small update to FLamby install instructions to avoid cluster failures.

### DIFF
--- a/research/flamby/README.md
+++ b/research/flamby/README.md
@@ -17,8 +17,10 @@ cd <fl4health_repository>
 pip install --upgrade pip poetry
 poetry install --with "dev, dev-local, test, codestyle"
 cd <FLamby_repository>
+pip install albumentations==1.4.20
 pip install -e ".[cam16, heart, isic2019, ixi, lidc, tcga]"
 ```
+__NOTE__: The forced install of albumentations 1.4.20 avoids an issue where versions > 1.4.20 rely on simsimd which does not compile on the Vector cluster
 __NOTE__: We avoid installing Fed-KITS2019, as it requires a fairly old version on nnUnet, which we no longer support in our library.
 
 In addition, you'll have to edit the code for `FedIXITiny` in `flamby/datasets/fed_ixi/datasets.py` replacing the following


### PR DESCRIPTION
# PR Type
Documentation

# Short Description

Albumentations upgraded to 1.4.21 on October 31st. They now rely on simsimd, which is not compatible with our cluster. So we pin to 1.4.20 to make stuff work.
