### PR TITLE
Add max_num_validation_steps member of config and client and related …

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -128,6 +128,8 @@ class BasicClient(NumPyClient):
         self.learning_rate: Optional[float] = None
         # Config can contain max_num_validation_steps key, which determines an upper bound
         # for the validation steps taken. If not specified, no upper bound will be enforced.
+        # By specifying this in the config we cannot guarantee the validation set is the same
+        # accross rounds for clients.
         self.max_num_validation_steps: int | None = None
 
     def _maybe_checkpoint(self, loss: float, metrics: dict[str, Scalar], checkpoint_mode: CheckpointMode) -> None:
@@ -839,6 +841,14 @@ class BasicClient(NumPyClient):
         self.test_loader = self.get_test_data_loader(config)
 
         if "max_num_validation_steps" in config:
+            log(
+                INFO,
+                """
+                    max_num_validation_steps specified in config. Only a random subset of batches will \
+                    be sampled from the validation set if max_num_validation_steps is greater \
+                    than the number of batches in the validation dataloader.
+                    """,
+            )
             self.max_num_validation_steps = narrow_dict_type(config, "max_num_validation_steps", int)
         else:
             self.max_num_validation_steps = None

--- a/tests/clients/test_basic_client.py
+++ b/tests/clients/test_basic_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import freezegun
 import torch
 from flwr.common import Scalar
+from flwr.common.typing import Config
 from freezegun import freeze_time
 
 from fl4health.clients.basic_client import BasicClient
@@ -83,7 +84,7 @@ def test_metrics_reporter_evaluate() -> None:
         "testing_metric": 1234,
         "val - checkpoint": 123.123,
         "test - checkpoint": 123.123,
-        "test - num_examples": 0,
+        "test - num_examples": 32,
     }
     reporter = JsonReporter()
     fl_client = MockBasicClient(
@@ -137,6 +138,19 @@ def test_evaluate_after_fit_disabled() -> None:
     fl_client.validate.assert_not_called()  # type: ignore
 
 
+def test_num_val_samples_correct() -> None:
+    fl_client_no_max = MockBasicClient()
+    fl_client_no_max.setup_client({})
+    assert fl_client_no_max.max_num_validation_steps is None
+    assert fl_client_no_max.num_val_samples == 32
+
+    fl_client_max = MockBasicClient()
+    config: Config = {"max_num_validation_steps": 2}
+    fl_client_max.setup_client(config)
+    assert fl_client_max.max_num_validation_steps == 2
+    assert fl_client_max.num_val_samples == 8
+
+
 class MockBasicClient(BasicClient):
     def __init__(
         self,
@@ -165,6 +179,7 @@ class MockBasicClient(BasicClient):
         self.test_loader = MagicMock()
         self.num_train_samples = 0
         self.num_val_samples = 0
+        self.max_num_validation_steps = None
 
         # Mocking methods
         self.set_parameters = MagicMock()  # type: ignore
@@ -176,7 +191,8 @@ class MockBasicClient(BasicClient):
         self.get_model = MagicMock()  # type: ignore
         self.get_data_loaders = MagicMock()  # type: ignore
         mock_data_loader = MagicMock()  # type: ignore
-        mock_data_loader.dataset = []
+        mock_data_loader.batch_size = 4
+        mock_data_loader.dataset = [None] * 32
         self.get_data_loaders.return_value = mock_data_loader, mock_data_loader
         self.get_test_data_loader = MagicMock()  # type: ignore
         self.get_test_data_loader.return_value = mock_data_loader


### PR DESCRIPTION
# PR Type
[**Feature** | Fix | Documentation | Other ]

# Short Description

[Add ability to specify maximum number of validation steps to perform](https://app.clickup.com/t/868bcpawz)

Add ability to specify maximum number of validation steps to perform. This functionality is useful in cases where the validation dataset size is large and we don't want to compute metrics over the entire validation set. This is immediately useful for the nnunet experiments because the [nnunet cli](https://github.com/MIC-DKFZ/nnUNet/blob/43349fa5f0680e8109a78dca7215c19e258c9dd7/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py#L151) only performs 50 steps on the validation set.

# Tests Added

Describe the tests that have been added to ensure the codes correctness, if applicable.
