### PR TITLE
Nnunet amp integration

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/fl4health/clients/nnunet_client.py
+++ b/fl4health/clients/nnunet_client.py
@@ -189,7 +189,7 @@ class NnunetClient(BasicClient):
         # Used to redirect stdout to logger
         self.stream2debug = StreamToLogger(FLOWER_LOGGER, DEBUG)
 
-        # Used to scale gradients if using mized precision training (true if device is cuda)
+        # Used to scale gradients if using mixed precision training (true if device is cuda)
         self.grad_scaler: GradScaler | None = GradScaler() if self.device.type == "cuda" else None
 
         # nnunet specific attributes to be initialized in setup_client


### PR DESCRIPTION
# PR Type
[**Feature** | Fix | Documentation | Other ]

# Short Description

Clickup Ticket(s): [Add Mixed Precision Training to NnuentClient](https://app.clickup.com/t/868beh5kf)

By default, if you have a CUDA GPU, nnUNetTrainer uses automatic mixed precision training. This casts down the weights and inputs/activation from fp32 to fp16 for certain sets of operations. Weights are kept in fp32 and downcasted. Gradients are compute in fp16 but accumulated in fp32. In order to realize automatic mixed precision training, we must wrap forward pass and loss computation in the autocast context. Additionally, the loss must be scaled to prevent underflow of the gradients which are computed in fp16. This is accomplished via the torch provided GradScaler. 
