### PR TITLE
Smoke test bug fix for Andrei with the state checkpointers

### DIFF
--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -303,17 +303,18 @@ class PerRoundStateCheckpointer:
             dict[str, Any]: A dictionary representing the checkpointed state, as loaded by torch.load.
         """
 
+        assert self.checkpoint_exists(checkpoint_name)
         checkpoint_path = os.path.join(self.checkpoint_dir, checkpoint_name)
         log(INFO, f"Loading state from checkpoint at {checkpoint_path}")
-        assert self.checkpoint_exists(checkpoint_path)
 
         return torch.load(checkpoint_path)
 
-    def checkpoint_exists(self, checkpoint_path: str) -> bool:
+    def checkpoint_exists(self, checkpoint_name: str) -> bool:
         """
         Checks if a checkpoint exists at the checkpoint_path constructed at initialization.
 
         Returns:
             bool: Whether or not a checkpoint exists.
         """
+        checkpoint_path = os.path.join(self.checkpoint_dir, checkpoint_name)
         return os.path.exists(checkpoint_path)

--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -311,7 +311,7 @@ class PerRoundStateCheckpointer:
 
     def checkpoint_exists(self, checkpoint_name: str) -> bool:
         """
-        Checks if a checkpoint exists at the checkpoint_path constructed at initialization.
+        Checks if a checkpoint exists at the checkpoint_dir + checkpoint_name constructed at initialization.
 
         Returns:
             bool: Whether or not a checkpoint exists.

--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -311,7 +311,7 @@ class PerRoundStateCheckpointer:
 
     def checkpoint_exists(self, checkpoint_name: str) -> bool:
         """
-        Checks if a checkpoint exists at the checkpoint_dir + checkpoint_name constructed at initialization.
+        Checks if a checkpoint exists at the checkpoint_dir constructed at initialization + checkpoint_name.
 
         Returns:
             bool: Whether or not a checkpoint exists.

--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -318,8 +318,7 @@ class PerRoundStateCheckpointer:
         """
         if "checkpoint_path" in kwargs:
             raise ValueError(
-                "Previously this checkpoint supported sending a path, but it requires now requires a "
-                "checkpoint_name only"
+                "Previously this checkpoint supported sending a path, but it now requires a checkpoint_name only"
             )
         checkpoint_path = os.path.join(self.checkpoint_dir, checkpoint_name)
         return os.path.exists(checkpoint_path)

--- a/fl4health/checkpointing/checkpointer.py
+++ b/fl4health/checkpointing/checkpointer.py
@@ -309,12 +309,17 @@ class PerRoundStateCheckpointer:
 
         return torch.load(checkpoint_path)
 
-    def checkpoint_exists(self, checkpoint_name: str) -> bool:
+    def checkpoint_exists(self, checkpoint_name: str, **kwargs: Any) -> bool:
         """
         Checks if a checkpoint exists at the checkpoint_dir constructed at initialization + checkpoint_name.
 
         Returns:
             bool: Whether or not a checkpoint exists.
         """
+        if "checkpoint_path" in kwargs:
+            raise ValueError(
+                "Previously this checkpoint supported sending a path, but it requires now requires a "
+                "checkpoint_name only"
+            )
         checkpoint_path = os.path.join(self.checkpoint_dir, checkpoint_name)
         return os.path.exists(checkpoint_path)

--- a/fl4health/checkpointing/server_module.py
+++ b/fl4health/checkpointing/server_module.py
@@ -194,6 +194,7 @@ class BaseServerCheckpointAndStateModule:
         """
         if self.state_checkpointer is not None:
             if self.state_checkpointer.checkpoint_exists(state_checkpoint_name):
+
                 return self.state_checkpointer.load_checkpoint(state_checkpoint_name)
             else:
                 log(INFO, "State checkpointer is defined but no state checkpoint exists.")

--- a/research/picai/single_node_trainer.py
+++ b/research/picai/single_node_trainer.py
@@ -33,7 +33,6 @@ class SingleNodeTrainer:
             os.mkdir(checkpoint_dir)
 
         self.state_checkpoint_name = "ckpt.pkl"
-        self.state_checkpoint_path = os.path.join(checkpoint_dir, self.state_checkpoint_name)
         self.per_epoch_checkpointer = PerRoundStateCheckpointer(Path(checkpoint_dir))
         best_metric_checkpoint_name = "best_ckpt.pkl"
         self.checkpointer = BestLossTorchModuleCheckpointer(checkpoint_dir, best_metric_checkpoint_name)
@@ -51,7 +50,7 @@ class SingleNodeTrainer:
                 self.state_checkpoint_name, {"model": self.model, "optimizer": self.optimizer, "epoch": 0}
             )
 
-        ckpt = self.per_epoch_checkpointer.load_checkpoint(self.state_checkpoint_path)
+        ckpt = self.per_epoch_checkpointer.load_checkpoint(self.state_checkpoint_name)
         self.model, self.optimizer, self.epoch = ckpt["model"], ckpt["optimizer"], ckpt["epoch"]
 
     def _maybe_checkpoint(self, loss: float, metrics: dict[str, Scalar]) -> None:

--- a/research/picai/single_node_trainer.py
+++ b/research/picai/single_node_trainer.py
@@ -46,7 +46,7 @@ class SingleNodeTrainer:
         self.device = device
         self.epoch: int
 
-        if not self.per_epoch_checkpointer.checkpoint_exists(self.state_checkpoint_path):
+        if not self.per_epoch_checkpointer.checkpoint_exists(self.state_checkpoint_name):
             self.per_epoch_checkpointer.save_checkpoint(
                 self.state_checkpoint_name, {"model": self.model, "optimizer": self.optimizer, "epoch": 0}
             )

--- a/tests/checkpointing/test_per_round_checkpointer.py
+++ b/tests/checkpointing/test_per_round_checkpointer.py
@@ -17,14 +17,14 @@ def test_per_round_checkpointer() -> None:
         checkpoint_path = os.path.join(results_dir, checkpoint_name)
         checkpointer = PerRoundStateCheckpointer(checkpoint_dir=Path(results_dir))
 
-        assert not checkpointer.checkpoint_exists(checkpoint_path)
+        assert not checkpointer.checkpoint_exists(checkpoint_name)
 
         checkpointer.save_checkpoint(
             checkpoint_name=checkpoint_name,
             checkpoint_dict={"model": model, "optimizer": optimizer, "current_round": 0},
         )
 
-        assert checkpointer.checkpoint_exists(checkpoint_path)
+        assert checkpointer.checkpoint_exists(checkpoint_name)
 
         ckpt = checkpointer.load_checkpoint(checkpoint_path)
 

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -551,7 +551,7 @@ class MetricType(Enum):
 
 
 DEFAULT_METRICS_FOLDER = Path("metrics")
-DEFAULT_TOLERANCE = 0.1
+DEFAULT_TOLERANCE = 0.0005
 
 
 def _assert_metrics(metric_type: MetricType, metrics_to_assert: dict[str, Any] | None = None) -> list[str]:


### PR DESCRIPTION
# PR Type
Fix

# Short Description

When switching off of the default directory "./" for the state checkpointer smoke tests, Andrei uncovered a bug in the way we were checking for the existence of a checkpoint and loading the intermediate state.

# Tests Added

Smoke tests now pass without the default directory specified.
