### PR TITLE
Move assert statements out of `run_smoke_test` and into the actual test (for graceful shutdown in case of failure)

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:  # for testing with github runners and stability
 
 jobs:
   test:

--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:  # for testing with github runners and stability
 
 jobs:
   test:

--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -47,4 +47,4 @@ jobs:
       - name: Run Script
         run: |
           source .venv/bin/activate
-          pytest -m "smoketest"
+          pytest -m "smoketest" -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,4 +108,3 @@ markers = [
     "smoketest: marks tests as smoke tests (deselect with '-m \"not smoketest\"')",
 ]
 asyncio_default_fixture_loop_scope = "session"
-asyncio_mode = "auto"

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -605,6 +605,14 @@ async def _wait_for_process_to_finish_and_retrieve_logs(
 ) -> str:
 
     async def get_output_from_stdout(stream_reader: asyncio.streams.StreamReader) -> tuple[str, int | None]:
+        """Reading from the stdout stream.
+
+        NOTE: In the initial implementation, we were invoking asyncio.wait_for()
+        with the coroutine stream_reader.readline() and with a timeout=timeout.
+        Outsourcing to this function now which we wrap this whole helper fn
+        with asyncio.wait_for() for improved readability and better error
+        handling, especially of the TimeoutError.
+        """
         full_output = ""
         while True:
             output_in_bytes = await stream_reader.readline()

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -33,6 +33,10 @@ class SmokeTestExecutionError(Exception):
     pass
 
 
+class SmokeTestTimeoutError(Exception):
+    pass
+
+
 def postprocess_logs(logs: str) -> str:
     """Postprocess logs to remove spurious Errors.
 
@@ -586,7 +590,7 @@ async def _wait_for_process_to_finish_and_retrieve_logs(
             raise SmokeTestExecutionError("Process stdout is None")
         full_output, return_code = await asyncio.wait_for(get_output_from_stdout(process.stdout), timeout=timeout)
     except asyncio.exceptions.TimeoutError as e:
-        raise SmokeTestExecutionError("Timeout for reading logs reached.") from e
+        raise SmokeTestTimeoutError("Timeout for reading logs reached.") from e
     except Exception as ex:
         logger.exception(f"Error collecting {process_name} log messages:")
         raise ex

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -15,7 +15,7 @@ from .run_smoke_test import (
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 # Marks all test coroutineutines in this module
-pytestmark = pytest.mark.asyncio(loop_scope="module")
+pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 async def try_running_test_task(task: asyncio.Task) -> None:

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -15,307 +15,451 @@ async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> No
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir(exist_ok=True)
 
-    await run_fault_tolerance_smoke_test(
-        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_fault_tolerance_smoke_test(
+            server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+            client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+            config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+            partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            seed=42,
+            server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+            client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+            intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_nnunet_config_2d(tolerance: float) -> None:
-    await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+            server_python_path="examples.nnunet_example.server",
+            client_python_path="examples.nnunet_example.client",
+            config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+            dataset_path="examples/datasets/nnunet",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_nnunet_config_3d(tolerance: float) -> None:
-    await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+            server_python_path="examples.nnunet_example.server",
+            client_python_path="examples.nnunet_example.client",
+            config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+            dataset_path="examples/datasets/nnunet",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_scaffold(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.scaffold_example.server",
-        client_python_path="examples.scaffold_example.client",
-        config_path="tests/smoke_tests/scaffold_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.scaffold_example.server",
+            client_python_path="examples.scaffold_example.client",
+            config_path="tests/smoke_tests/scaffold_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            seed=42,
+            server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+            client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_apfl(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.apfl_example.server",
-        client_python_path="examples.apfl_example.client",
-        config_path="tests/smoke_tests/apfl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.apfl_example.server",
+            client_python_path="examples.apfl_example.client",
+            config_path="tests/smoke_tests/apfl_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            seed=42,
+            server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+            client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_feddg_ga(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.feddg_ga_example.server",
-        client_python_path="examples.feddg_ga_example.client",
-        config_path="tests/smoke_tests/feddg_ga_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.feddg_ga_example.server",
+            client_python_path="examples.feddg_ga_example.client",
+            config_path="tests/smoke_tests/feddg_ga_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            seed=42,
+            server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+            client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_basic(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.basic_example.server",
-        client_python_path="examples.basic_example.client",
-        config_path="tests/smoke_tests/basic_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.basic_example.server",
+            client_python_path="examples.basic_example.client",
+            config_path="tests/smoke_tests/basic_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_client_level_dp_cifar(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp.client",
-        config_path="tests/smoke_tests/client_level_dp_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.dp_fed_examples.client_level_dp.server",
+            client_python_path="examples.dp_fed_examples.client_level_dp.client",
+            config_path="tests/smoke_tests/client_level_dp_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            skip_assert_client_fl_rounds=True,
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
-        config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
-        dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
+            client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
+            config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
+            dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
+            skip_assert_client_fl_rounds=True,
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_instance_level_dp_cifar(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.dp_fed_examples.instance_level_dp.server",
-        client_python_path="examples.dp_fed_examples.instance_level_dp.client",
-        config_path="tests/smoke_tests/instance_level_dp_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.dp_fed_examples.instance_level_dp.server",
+            client_python_path="examples.dp_fed_examples.instance_level_dp.client",
+            config_path="tests/smoke_tests/instance_level_dp_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            skip_assert_client_fl_rounds=True,
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_dp_scaffold(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.dp_scaffold_example.server",
-        client_python_path="examples.dp_scaffold_example.client",
-        config_path="tests/smoke_tests/dp_scaffold_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.dp_scaffold_example.server",
+            client_python_path="examples.dp_scaffold_example.client",
+            config_path="tests/smoke_tests/dp_scaffold_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fedbn(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fedbn_example.server",
-        client_python_path="examples.fedbn_example.client",
-        config_path="tests/smoke_tests/fedbn_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fedbn_example.server",
+            client_python_path="examples.fedbn_example.client",
+            config_path="tests/smoke_tests/fedbn_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fed_eval(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.federated_eval_example.server",
-        client_python_path="examples.federated_eval_example.client",
-        config_path="tests/smoke_tests/federated_eval_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-        assert_evaluation_logs=True,
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.federated_eval_example.server",
+            client_python_path="examples.federated_eval_example.client",
+            config_path="tests/smoke_tests/federated_eval_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+            assert_evaluation_logs=True,
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fedper_mnist(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fedper_example.server",
-        client_python_path="examples.fedper_example.client",
-        config_path="tests/smoke_tests/fedper_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fedper_example.server",
+            client_python_path="examples.fedper_example.client",
+            config_path="tests/smoke_tests/fedper_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fedper_cifar(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fedrep_example.server",
-        client_python_path="examples.fedrep_example.client",
-        config_path="tests/smoke_tests/fedrep_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fedrep_example.server",
+            client_python_path="examples.fedrep_example.client",
+            config_path="tests/smoke_tests/fedrep_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_ditto_mnist() -> None:
-    await run_smoke_test(
-        server_python_path="examples.ditto_example.server",
-        client_python_path="examples.ditto_example.client",
-        config_path="tests/smoke_tests/ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.ditto_example.server",
+            client_python_path="examples.ditto_example.client",
+            config_path="tests/smoke_tests/ditto_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_mr_mtl_mnist(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.mr_mtl_example.server",
-        client_python_path="examples.mr_mtl_example.client",
-        config_path="tests/smoke_tests/mr_mtl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.mr_mtl_example.server",
+            client_python_path="examples.mr_mtl_example.client",
+            config_path="tests/smoke_tests/mr_mtl_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fenda(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fenda_example.server",
-        client_python_path="examples.fenda_example.client",
-        config_path="tests/smoke_tests/fenda_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fenda_example.server",
+            client_python_path="examples.fenda_example.client",
+            config_path="tests/smoke_tests/fenda_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fenda_ditto(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fenda_ditto_example.server",
-        client_python_path="examples.fenda_ditto_example.client",
-        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        checkpoint_path="examples/assets/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fenda_ditto_example.server",
+            client_python_path="examples.fenda_ditto_example.client",
+            config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            checkpoint_path="examples/assets/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_perfcl(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.perfcl_example.server",
-        client_python_path="examples.perfcl_example.client",
-        config_path="tests/smoke_tests/perfcl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.perfcl_example.server",
+            client_python_path="examples.perfcl_example.client",
+            config_path="tests/smoke_tests/perfcl_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_fl_plus_local(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.fl_plus_local_ft_example.server",
-        client_python_path="examples.fl_plus_local_ft_example.client",
-        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.fl_plus_local_ft_example.server",
+            client_python_path="examples.fl_plus_local_ft_example.client",
+            config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_moon(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.moon_example.server",
-        client_python_path="examples.moon_example.client",
-        config_path="tests/smoke_tests/moon_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.moon_example.server",
+            client_python_path="examples.moon_example.client",
+            config_path="tests/smoke_tests/moon_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_ensemble(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.ensemble_example.server",
-        client_python_path="examples.ensemble_example.client",
-        config_path="tests/smoke_tests/ensemble_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.ensemble_example.server",
+            client_python_path="examples.ensemble_example.client",
+            config_path="tests/smoke_tests/ensemble_config.yaml",
+            dataset_path="examples/datasets/mnist_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 @pytest.mark.asyncio()
 async def test_flash(tolerance: float) -> None:
-    await run_smoke_test(
-        server_python_path="examples.flash_example.server",
-        client_python_path="examples.flash_example.client",
-        config_path="tests/smoke_tests/flash_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
+    try:
+        server_errors, client_errors = await run_smoke_test(
+            server_python_path="examples.flash_example.server",
+            client_python_path="examples.flash_example.client",
+            config_path="tests/smoke_tests/flash_config.yaml",
+            dataset_path="examples/datasets/cifar_data/",
+            tolerance=tolerance,
+        )
+    except Exception as e:
+        pytest.fail(f"Smoke test execution failed: {e}")
+
+    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
-from pathlib import Path
 
 import pytest
 
-from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
+# from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
+from .run_smoke_test import run_smoke_test
+
+# from pathlib import Path
+
 
 # from pathlib import Path
 
@@ -37,143 +40,167 @@ def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoo
             event_loop.run_forever()
 
 
-@pytest.mark.smoketest
-async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-    checkpoint_dir = tmp_path / "checkpoints"
-    checkpoint_dir.mkdir(exist_ok=True)
-    coro = run_fault_tolerance_smoke_test(
-        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+#     checkpoint_dir = tmp_path / "checkpoints"
+#     checkpoint_dir.mkdir(exist_ok=True)
+#     coro = run_fault_tolerance_smoke_test(
+#         server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+#         client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+#         config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+#         partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+#         intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_nnunet_config_2d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_nnunet_config_2d(tolerance: float) -> None:
+#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#         server_python_path="examples.nnunet_example.server",
+#         client_python_path="examples.nnunet_example.client",
+#         config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+#         dataset_path="examples/datasets/nnunet",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_nnunet_config_3d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_nnunet_config_3d(tolerance: float) -> None:
+#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#         server_python_path="examples.nnunet_example.server",
+#         client_python_path="examples.nnunet_example.client",
+#         config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+#         dataset_path="examples/datasets/nnunet",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_scaffold(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.scaffold_example.server",
-        client_python_path="examples.scaffold_example.client",
-        config_path="tests/smoke_tests/scaffold_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_scaffold(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.scaffold_example.server",
+#         client_python_path="examples.scaffold_example.client",
+#         config_path="tests/smoke_tests/scaffold_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_apfl(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.apfl_example.server",
-        client_python_path="examples.apfl_example.client",
-        config_path="tests/smoke_tests/apfl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_apfl(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.apfl_example.server",
+#         client_python_path="examples.apfl_example.client",
+#         config_path="tests/smoke_tests/apfl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_feddg_ga(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.feddg_ga_example.server",
-        client_python_path="examples.feddg_ga_example.client",
-        config_path="tests/smoke_tests/feddg_ga_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_feddg_ga(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.feddg_ga_example.server",
+#         client_python_path="examples.feddg_ga_example.client",
+#         config_path="tests/smoke_tests/feddg_ga_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_basic(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.basic_example.server",
-        client_python_path="examples.basic_example.client",
-        config_path="tests/smoke_tests/basic_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_basic(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.basic_example.server",
+#         client_python_path="examples.basic_example.client",
+#         config_path="tests/smoke_tests/basic_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_client_level_dp_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp.client",
-        config_path="tests/smoke_tests/client_level_dp_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_client_level_dp_cifar(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.dp_fed_examples.client_level_dp.server",
+#         client_python_path="examples.dp_fed_examples.client_level_dp.client",
+#         config_path="tests/smoke_tests/client_level_dp_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         skip_assert_client_fl_rounds=True,
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
 @pytest.mark.smoketest
@@ -188,7 +215,10 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
     )
     task = asyncio.create_task(coro)
     event_loop = asyncio.get_event_loop()
-    await task
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
 
@@ -204,7 +234,10 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
     )
     task = asyncio.create_task(coro)
     event_loop = asyncio.get_event_loop()
-    await task
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
 
@@ -219,7 +252,10 @@ async def test_dp_scaffold(tolerance: float) -> None:
     )
     task = asyncio.create_task(coro)
     event_loop = asyncio.get_event_loop()
-    await task
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
 
@@ -234,187 +270,226 @@ async def test_fedbn(tolerance: float) -> None:
     )
     task = asyncio.create_task(coro)
     event_loop = asyncio.get_event_loop()
-    await task
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fed_eval(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.federated_eval_example.server",
-        client_python_path="examples.federated_eval_example.client",
-        config_path="tests/smoke_tests/federated_eval_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-        assert_evaluation_logs=True,
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fed_eval(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.federated_eval_example.server",
+#         client_python_path="examples.federated_eval_example.client",
+#         config_path="tests/smoke_tests/federated_eval_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+#         assert_evaluation_logs=True,
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fedper_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fedper_example.server",
-        client_python_path="examples.fedper_example.client",
-        config_path="tests/smoke_tests/fedper_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fedper_mnist(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fedper_example.server",
+#         client_python_path="examples.fedper_example.client",
+#         config_path="tests/smoke_tests/fedper_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fedper_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fedrep_example.server",
-        client_python_path="examples.fedrep_example.client",
-        config_path="tests/smoke_tests/fedrep_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fedper_cifar(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fedrep_example.server",
+#         client_python_path="examples.fedrep_example.client",
+#         config_path="tests/smoke_tests/fedrep_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_ditto_mnist() -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.ditto_example.server",
-        client_python_path="examples.ditto_example.client",
-        config_path="tests/smoke_tests/ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_ditto_mnist() -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.ditto_example.server",
+#         client_python_path="examples.ditto_example.client",
+#         config_path="tests/smoke_tests/ditto_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_mr_mtl_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.mr_mtl_example.server",
-        client_python_path="examples.mr_mtl_example.client",
-        config_path="tests/smoke_tests/mr_mtl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_mr_mtl_mnist(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.mr_mtl_example.server",
+#         client_python_path="examples.mr_mtl_example.client",
+#         config_path="tests/smoke_tests/mr_mtl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fenda(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fenda_example.server",
-        client_python_path="examples.fenda_example.client",
-        config_path="tests/smoke_tests/fenda_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fenda(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fenda_example.server",
+#         client_python_path="examples.fenda_example.client",
+#         config_path="tests/smoke_tests/fenda_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fenda_ditto(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fenda_ditto_example.server",
-        client_python_path="examples.fenda_ditto_example.client",
-        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        checkpoint_path="examples/assets/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fenda_ditto(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fenda_ditto_example.server",
+#         client_python_path="examples.fenda_ditto_example.client",
+#         config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         checkpoint_path="examples/assets/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_perfcl(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.perfcl_example.server",
-        client_python_path="examples.perfcl_example.client",
-        config_path="tests/smoke_tests/perfcl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_perfcl(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.perfcl_example.server",
+#         client_python_path="examples.perfcl_example.client",
+#         config_path="tests/smoke_tests/perfcl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fl_plus_local(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fl_plus_local_ft_example.server",
-        client_python_path="examples.fl_plus_local_ft_example.client",
-        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fl_plus_local(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fl_plus_local_ft_example.server",
+#         client_python_path="examples.fl_plus_local_ft_example.client",
+#         config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_moon(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.moon_example.server",
-        client_python_path="examples.moon_example.client",
-        config_path="tests/smoke_tests/moon_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_moon(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.moon_example.server",
+#         client_python_path="examples.moon_example.client",
+#         config_path="tests/smoke_tests/moon_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_ensemble(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.ensemble_example.server",
-        client_python_path="examples.ensemble_example.client",
-        config_path="tests/smoke_tests/ensemble_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_ensemble(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.ensemble_example.server",
+#         client_python_path="examples.ensemble_example.client",
+#         config_path="tests/smoke_tests/ensemble_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_flash(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.flash_example.server",
-        client_python_path="examples.flash_example.client",
-        config_path="tests/smoke_tests/flash_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    await task
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_flash(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.flash_example.server",
+#         client_python_path="examples.flash_example.client",
+#         config_path="tests/smoke_tests/flash_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except asyncio.exceptions.TimeoutError:
+#         pytest.fail("Smoke test failed due to Timeout Error.")
+#     assert_on_done_task(task, event_loop)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -9,7 +9,7 @@ from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_te
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 # Marks all test coroutines in this module
-pytestmark = pytest.mark.asyncio(loop_scope="session")
+pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
 @pytest.mark.smoketest

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,9 +1,12 @@
+import asyncio
 import os
-from pathlib import Path
 
 import pytest
 
-from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
+from .run_smoke_test import run_smoke_test  # load_metrics_from_file,; run_fault_tolerance_smoke_test,
+
+# from pathlib import Path
+
 
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
@@ -12,164 +15,165 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
-@pytest.mark.smoketest
-async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-    checkpoint_dir = tmp_path / "checkpoints"
-    checkpoint_dir.mkdir(exist_ok=True)
+# @pytest.mark.smoketest
+# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+#     checkpoint_dir = tmp_path / "checkpoints"
+#     checkpoint_dir.mkdir(exist_ok=True)
 
-    try:
-        server_errors, client_errors = await run_fault_tolerance_smoke_test(
-            server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-            client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-            config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-            partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            seed=42,
-            server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-            client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-            intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+#     try:
+#         server_errors, client_errors = await run_fault_tolerance_smoke_test(
+#             server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+#             client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+#             config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+#             partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             seed=42,
+#             server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+#             client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+#             intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_nnunet_config_2d(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-            server_python_path="examples.nnunet_example.server",
-            client_python_path="examples.nnunet_example.client",
-            config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-            dataset_path="examples/datasets/nnunet",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_nnunet_config_3d(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-            server_python_path="examples.nnunet_example.server",
-            client_python_path="examples.nnunet_example.client",
-            config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-            dataset_path="examples/datasets/nnunet",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_nnunet_config_2d(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#             server_python_path="examples.nnunet_example.server",
+#             client_python_path="examples.nnunet_example.client",
+#             config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+#             dataset_path="examples/datasets/nnunet",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_scaffold(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.scaffold_example.server",
-            client_python_path="examples.scaffold_example.client",
-            config_path="tests/smoke_tests/scaffold_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            seed=42,
-            server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-            client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_apfl(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.apfl_example.server",
-            client_python_path="examples.apfl_example.client",
-            config_path="tests/smoke_tests/apfl_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            seed=42,
-            server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-            client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_nnunet_config_3d(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#             server_python_path="examples.nnunet_example.server",
+#             client_python_path="examples.nnunet_example.client",
+#             config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+#             dataset_path="examples/datasets/nnunet",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_feddg_ga(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.feddg_ga_example.server",
-            client_python_path="examples.feddg_ga_example.client",
-            config_path="tests/smoke_tests/feddg_ga_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            seed=42,
-            server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-            client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_scaffold(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.scaffold_example.server",
+#             client_python_path="examples.scaffold_example.client",
+#             config_path="tests/smoke_tests/scaffold_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             seed=42,
+#             server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+#             client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_basic(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.basic_example.server",
-            client_python_path="examples.basic_example.client",
-            config_path="tests/smoke_tests/basic_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_client_level_dp_cifar(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.dp_fed_examples.client_level_dp.server",
-            client_python_path="examples.dp_fed_examples.client_level_dp.client",
-            config_path="tests/smoke_tests/client_level_dp_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            skip_assert_client_fl_rounds=True,
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_apfl(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.apfl_example.server",
+#             client_python_path="examples.apfl_example.client",
+#             config_path="tests/smoke_tests/apfl_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             seed=42,
+#             server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+#             client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_feddg_ga(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.feddg_ga_example.server",
+#             client_python_path="examples.feddg_ga_example.client",
+#             config_path="tests/smoke_tests/feddg_ga_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             seed=42,
+#             server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+#             client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_basic(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.basic_example.server",
+#             client_python_path="examples.basic_example.client",
+#             config_path="tests/smoke_tests/basic_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_client_level_dp_cifar(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.dp_fed_examples.client_level_dp.server",
+#             client_python_path="examples.dp_fed_examples.client_level_dp.client",
+#             config_path="tests/smoke_tests/client_level_dp_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             skip_assert_client_fl_rounds=True,
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
 @pytest.mark.smoketest
 async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
@@ -180,6 +184,11 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -188,6 +197,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_instance_level_dp_cifar(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.dp_fed_examples.instance_level_dp.server",
@@ -198,6 +208,11 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -206,6 +221,7 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_dp_scaffold(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.dp_scaffold_example.server",
@@ -215,6 +231,11 @@ async def test_dp_scaffold(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -223,6 +244,7 @@ async def test_dp_scaffold(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_fedbn(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.fedbn_example.server",
@@ -232,6 +254,11 @@ async def test_fedbn(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -240,6 +267,7 @@ async def test_fedbn(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_fed_eval(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.federated_eval_example.server",
@@ -251,6 +279,11 @@ async def test_fed_eval(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -259,6 +292,7 @@ async def test_fed_eval(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_fedper_mnist(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
     try:
         server_errors, client_errors = await run_smoke_test(
             server_python_path="examples.fedper_example.server",
@@ -268,177 +302,182 @@ async def test_fedper_mnist(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
+        # proper clean up of cancelled tasks before stopping event_loop
+        lingering_tasks = asyncio.all_tasks()
+        if lingering_tasks:
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_fedper_cifar(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.fedrep_example.server",
-            client_python_path="examples.fedrep_example.client",
-            config_path="tests/smoke_tests/fedrep_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_fedper_cifar(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.fedrep_example.server",
+#             client_python_path="examples.fedrep_example.client",
+#             config_path="tests/smoke_tests/fedrep_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_ditto_mnist() -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.ditto_example.server",
-            client_python_path="examples.ditto_example.client",
-            config_path="tests/smoke_tests/ditto_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_mr_mtl_mnist(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.mr_mtl_example.server",
-            client_python_path="examples.mr_mtl_example.client",
-            config_path="tests/smoke_tests/mr_mtl_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_ditto_mnist() -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.ditto_example.server",
+#             client_python_path="examples.ditto_example.client",
+#             config_path="tests/smoke_tests/ditto_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_fenda(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.fenda_example.server",
-            client_python_path="examples.fenda_example.client",
-            config_path="tests/smoke_tests/fenda_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_fenda_ditto(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.fenda_ditto_example.server",
-            client_python_path="examples.fenda_ditto_example.client",
-            config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            checkpoint_path="examples/assets/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_mr_mtl_mnist(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.mr_mtl_example.server",
+#             client_python_path="examples.mr_mtl_example.client",
+#             config_path="tests/smoke_tests/mr_mtl_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_perfcl(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.perfcl_example.server",
-            client_python_path="examples.perfcl_example.client",
-            config_path="tests/smoke_tests/perfcl_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_fl_plus_local(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.fl_plus_local_ft_example.server",
-            client_python_path="examples.fl_plus_local_ft_example.client",
-            config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_fenda(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.fenda_example.server",
+#             client_python_path="examples.fenda_example.client",
+#             config_path="tests/smoke_tests/fenda_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_moon(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.moon_example.server",
-            client_python_path="examples.moon_example.client",
-            config_path="tests/smoke_tests/moon_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_ensemble(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.ensemble_example.server",
-            client_python_path="examples.ensemble_example.client",
-            config_path="tests/smoke_tests/ensemble_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_fenda_ditto(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.fenda_ditto_example.server",
+#             client_python_path="examples.fenda_ditto_example.client",
+#             config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             checkpoint_path="examples/assets/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_flash(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.flash_example.server",
-            client_python_path="examples.flash_example.client",
-            config_path="tests/smoke_tests/flash_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
+# @pytest.mark.smoketest
+# async def test_perfcl(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.perfcl_example.server",
+#             client_python_path="examples.perfcl_example.client",
+#             config_path="tests/smoke_tests/perfcl_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
 
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_fl_plus_local(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.fl_plus_local_ft_example.server",
+#             client_python_path="examples.fl_plus_local_ft_example.client",
+#             config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_moon(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.moon_example.server",
+#             client_python_path="examples.moon_example.client",
+#             config_path="tests/smoke_tests/moon_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_ensemble(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.ensemble_example.server",
+#             client_python_path="examples.ensemble_example.client",
+#             config_path="tests/smoke_tests/ensemble_config.yaml",
+#             dataset_path="examples/datasets/mnist_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+
+
+# @pytest.mark.smoketest
+# async def test_flash(tolerance: float) -> None:
+#     try:
+#         server_errors, client_errors = await run_smoke_test(
+#             server_python_path="examples.flash_example.server",
+#             client_python_path="examples.flash_example.client",
+#             config_path="tests/smoke_tests/flash_config.yaml",
+#             dataset_path="examples/datasets/cifar_data/",
+#             tolerance=tolerance,
+#         )
+#     except Exception as e:
+#         pytest.fail(f"Smoke test execution failed: {e}")
+
+#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
+#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,13 +1,15 @@
 import asyncio
 import os
+from pathlib import Path
 
 import pytest
 
-# from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
-from .run_smoke_test import run_smoke_test
-
-# from pathlib import Path
-
+from .run_smoke_test import (
+    SmokeTestTimeoutError,
+    load_metrics_from_file,
+    run_fault_tolerance_smoke_test,
+    run_smoke_test,
+)
 
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
@@ -33,195 +35,21 @@ def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoo
         assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-# @pytest.mark.smoketest
-# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-#     checkpoint_dir = tmp_path / "checkpoints"
-#     checkpoint_dir.mkdir(exist_ok=True)
-#     coro = run_fault_tolerance_smoke_test(
-#         server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-#         client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-#         config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-#         partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-#         intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.smoketest
-# async def test_nnunet_config_2d(tolerance: float) -> None:
-#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#         server_python_path="examples.nnunet_example.server",
-#         client_python_path="examples.nnunet_example.client",
-#         config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-#         dataset_path="examples/datasets/nnunet",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.smoketest
-# async def test_nnunet_config_3d(tolerance: float) -> None:
-#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#         server_python_path="examples.nnunet_example.server",
-#         client_python_path="examples.nnunet_example.client",
-#         config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-#         dataset_path="examples/datasets/nnunet",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.smoketest
-# async def test_scaffold(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.scaffold_example.server",
-#         client_python_path="examples.scaffold_example.client",
-#         config_path="tests/smoke_tests/scaffold_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_apfl(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.apfl_example.server",
-#         client_python_path="examples.apfl_example.client",
-#         config_path="tests/smoke_tests/apfl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_feddg_ga(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.feddg_ga_example.server",
-#         client_python_path="examples.feddg_ga_example.client",
-#         config_path="tests/smoke_tests/feddg_ga_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.smoketest
-# async def test_basic(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.basic_example.server",
-#         client_python_path="examples.basic_example.client",
-#         config_path="tests/smoke_tests/basic_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
-# @pytest.mark.smoketest
-# async def test_client_level_dp_cifar(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.dp_fed_examples.client_level_dp.server",
-#         client_python_path="examples.dp_fed_examples.client_level_dp.client",
-#         config_path="tests/smoke_tests/client_level_dp_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         skip_assert_client_fl_rounds=True,
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
-
-
 @pytest.mark.smoketest
-async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
-        config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
-        dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
-        skip_assert_client_fl_rounds=True,
+async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir(exist_ok=True)
+    coro = run_fault_tolerance_smoke_test(
+        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
         tolerance=tolerance,
-        read_logs_timeout=1,
     )
     task = asyncio.create_task(coro)
     event_loop = asyncio.get_event_loop()
@@ -231,6 +59,192 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_nnunet_config_2d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_nnunet_config_3d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_scaffold(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.scaffold_example.server",
+        client_python_path="examples.scaffold_example.client",
+        config_path="tests/smoke_tests/scaffold_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_apfl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.apfl_example.server",
+        client_python_path="examples.apfl_example.client",
+        config_path="tests/smoke_tests/apfl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_feddg_ga(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.feddg_ga_example.server",
+        client_python_path="examples.feddg_ga_example.client",
+        config_path="tests/smoke_tests/feddg_ga_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_basic(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.basic_example.server",
+        client_python_path="examples.basic_example.client",
+        config_path="tests/smoke_tests/basic_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_client_level_dp_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.dp_fed_examples.client_level_dp.server",
+        client_python_path="examples.dp_fed_examples.client_level_dp.client",
+        config_path="tests/smoke_tests/client_level_dp_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        skip_assert_client_fl_rounds=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
+    event_loop = asyncio.get_event_loop()
+    num_attempts = 2
+    for attempt in range(num_attempts):
+        try:
+            coro = run_smoke_test(
+                server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
+                client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
+                config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
+                dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
+                skip_assert_client_fl_rounds=True,
+                tolerance=tolerance,
+            )
+            task = asyncio.create_task(coro)
+            await task
+        except SmokeTestTimeoutError as e:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+            if attempt == 0:
+                # This test is a bit wonky and sometimes fails transiently where
+                # networking fails to communicate and timeout is reached. A simple
+                # retry should do the trick and so we do this automatically here
+                continue
+            else:
+                pytest.fail(f"Smoke test failed due to error after {attempt + 1} attempts. {e}")
+        except Exception as e:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+            pytest.fail(f"Smoke test failed due to error after {attempt + 1} attempts. {e}")
+
     assert_on_done_task(task, event_loop)
 
 
@@ -275,263 +289,263 @@ async def test_dp_scaffold(tolerance: float) -> None:
     assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedbn(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fedbn_example.server",
-#         client_python_path="examples.fedbn_example.client",
-#         config_path="tests/smoke_tests/fedbn_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fedbn(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedbn_example.server",
+        client_python_path="examples.fedbn_example.client",
+        config_path="tests/smoke_tests/fedbn_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fed_eval(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.federated_eval_example.server",
-#         client_python_path="examples.federated_eval_example.client",
-#         config_path="tests/smoke_tests/federated_eval_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-#         assert_evaluation_logs=True,
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fed_eval(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.federated_eval_example.server",
+        client_python_path="examples.federated_eval_example.client",
+        config_path="tests/smoke_tests/federated_eval_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+        assert_evaluation_logs=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_mnist(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fedper_example.server",
-#         client_python_path="examples.fedper_example.client",
-#         config_path="tests/smoke_tests/fedper_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fedper_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedper_example.server",
+        client_python_path="examples.fedper_example.client",
+        config_path="tests/smoke_tests/fedper_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_cifar(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fedrep_example.server",
-#         client_python_path="examples.fedrep_example.client",
-#         config_path="tests/smoke_tests/fedrep_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fedper_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedrep_example.server",
+        client_python_path="examples.fedrep_example.client",
+        config_path="tests/smoke_tests/fedrep_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ditto_mnist() -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.ditto_example.server",
-#         client_python_path="examples.ditto_example.client",
-#         config_path="tests/smoke_tests/ditto_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_ditto_mnist() -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ditto_example.server",
+        client_python_path="examples.ditto_example.client",
+        config_path="tests/smoke_tests/ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_mr_mtl_mnist(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.mr_mtl_example.server",
-#         client_python_path="examples.mr_mtl_example.client",
-#         config_path="tests/smoke_tests/mr_mtl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_mr_mtl_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.mr_mtl_example.server",
+        client_python_path="examples.mr_mtl_example.client",
+        config_path="tests/smoke_tests/mr_mtl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fenda_example.server",
-#         client_python_path="examples.fenda_example.client",
-#         config_path="tests/smoke_tests/fenda_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fenda(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_example.server",
+        client_python_path="examples.fenda_example.client",
+        config_path="tests/smoke_tests/fenda_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda_ditto(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fenda_ditto_example.server",
-#         client_python_path="examples.fenda_ditto_example.client",
-#         config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         checkpoint_path="examples/assets/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fenda_ditto(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_ditto_example.server",
+        client_python_path="examples.fenda_ditto_example.client",
+        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        checkpoint_path="examples/assets/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_perfcl(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.perfcl_example.server",
-#         client_python_path="examples.perfcl_example.client",
-#         config_path="tests/smoke_tests/perfcl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_perfcl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.perfcl_example.server",
+        client_python_path="examples.perfcl_example.client",
+        config_path="tests/smoke_tests/perfcl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fl_plus_local(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fl_plus_local_ft_example.server",
-#         client_python_path="examples.fl_plus_local_ft_example.client",
-#         config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fl_plus_local(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fl_plus_local_ft_example.server",
+        client_python_path="examples.fl_plus_local_ft_example.client",
+        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_moon(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.moon_example.server",
-#         client_python_path="examples.moon_example.client",
-#         config_path="tests/smoke_tests/moon_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_moon(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.moon_example.server",
+        client_python_path="examples.moon_example.client",
+        config_path="tests/smoke_tests/moon_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ensemble(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.ensemble_example.server",
-#         client_python_path="examples.ensemble_example.client",
-#         config_path="tests/smoke_tests/ensemble_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_ensemble(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ensemble_example.server",
+        client_python_path="examples.ensemble_example.client",
+        config_path="tests/smoke_tests/ensemble_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_flash(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.flash_example.server",
-#         client_python_path="examples.flash_example.client",
-#         config_path="tests/smoke_tests/flash_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except Exception as e:
-#         task.cancel()
-#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-#         pytest.fail(f"Smoke test failed due to error. {e}")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_flash(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.flash_example.server",
+        client_python_path="examples.flash_example.client",
+        config_path="tests/smoke_tests/flash_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
+    assert_on_done_task(task, event_loop)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -18,7 +18,7 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
-def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoop) -> None:
+def assert_on_done_task(task: asyncio.Task) -> None:
     """This function takes a done task and makes assert if a result was returned.
 
     If an exception was returned, then it fails the pytest for proper shutdown.
@@ -52,14 +52,14 @@ async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> No
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -72,14 +72,14 @@ async def test_nnunet_config_2d(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -92,14 +92,14 @@ async def test_nnunet_config_3d(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -115,14 +115,14 @@ async def test_scaffold(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
@@ -139,14 +139,14 @@ async def test_apfl(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
@@ -163,14 +163,14 @@ async def test_feddg_ga(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -183,14 +183,14 @@ async def test_basic(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -204,19 +204,19 @@ async def test_client_level_dp_cifar(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
-    event_loop = asyncio.get_event_loop()
+
     num_attempts = 2
     for attempt in range(num_attempts):
         try:
@@ -245,7 +245,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
             await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
             pytest.fail(f"Smoke test failed due to error after {attempt + 1} attempts. {e}")
 
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -259,14 +259,14 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -279,14 +279,14 @@ async def test_dp_scaffold(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -299,14 +299,14 @@ async def test_fedbn(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -321,14 +321,14 @@ async def test_fed_eval(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -341,14 +341,14 @@ async def test_fedper_mnist(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -361,14 +361,14 @@ async def test_fedper_cifar(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -380,14 +380,14 @@ async def test_ditto_mnist() -> None:
         dataset_path="examples/datasets/mnist_data/",
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -400,14 +400,14 @@ async def test_mr_mtl_mnist(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -420,14 +420,14 @@ async def test_fenda(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -441,14 +441,14 @@ async def test_fenda_ditto(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -461,14 +461,14 @@ async def test_perfcl(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -481,14 +481,14 @@ async def test_fl_plus_local(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -501,14 +501,14 @@ async def test_moon(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -521,14 +521,14 @@ async def test_ensemble(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
@@ -541,11 +541,11 @@ async def test_flash(tolerance: float) -> None:
         tolerance=tolerance,
     )
     task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
+
     try:
         await task
     except Exception as e:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+    assert_on_done_task(task)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -182,7 +182,7 @@ async def test_client_level_dp_cifar(tolerance: float) -> None:
 @pytest.mark.smoketest
 async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
 
-    num_attempts = 2
+    num_attempts = 3
     for attempt in range(num_attempts):
         try:
             coroutine = run_smoke_test(
@@ -198,7 +198,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
         except SmokeTestTimeoutError as e:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-            if attempt == 0:
+            if attempt < num_attempts - 1:
                 # This test is a bit wonky and sometimes fails transiently where
                 # networking fails to communicate and timeout is reached. A simple
                 # retry should do the trick and so we do this automatically here

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -14,8 +14,21 @@ from .run_smoke_test import (
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
-# Marks all test coroutines in this module
+# Marks all test coroutineutines in this module
 pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+
+async def try_running_test_task(task: asyncio.Task) -> None:
+    """Helper for running task.
+
+    If an exception is reached, then cancel the task and wait for it to be cleared.
+    """
+    try:
+        await task
+    except Exception as e:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+        pytest.fail(f"Smoke test failed due to error. {e}")
 
 
 def assert_on_done_task(task: asyncio.Task) -> None:
@@ -39,7 +52,7 @@ def assert_on_done_task(task: asyncio.Task) -> None:
 async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir(exist_ok=True)
-    coro = run_fault_tolerance_smoke_test(
+    coroutine = run_fault_tolerance_smoke_test(
         server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
         client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
         config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
@@ -51,60 +64,42 @@ async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> No
         intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_nnunet_config_2d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+    coroutine = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
         server_python_path="examples.nnunet_example.server",
         client_python_path="examples.nnunet_example.client",
         config_path="tests/smoke_tests/nnunet_config_2d.yaml",
         dataset_path="examples/datasets/nnunet",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_nnunet_config_3d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+    coroutine = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
         server_python_path="examples.nnunet_example.server",
         client_python_path="examples.nnunet_example.client",
         config_path="tests/smoke_tests/nnunet_config_3d.yaml",
         dataset_path="examples/datasets/nnunet",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_scaffold(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.scaffold_example.server",
         client_python_path="examples.scaffold_example.client",
         config_path="tests/smoke_tests/scaffold_config.yaml",
@@ -114,21 +109,15 @@ async def test_scaffold(tolerance: float) -> None:
         client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
 async def test_apfl(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.apfl_example.server",
         client_python_path="examples.apfl_example.client",
         config_path="tests/smoke_tests/apfl_config.yaml",
@@ -138,21 +127,15 @@ async def test_apfl(tolerance: float) -> None:
         client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
 async def test_feddg_ga(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.feddg_ga_example.server",
         client_python_path="examples.feddg_ga_example.client",
         config_path="tests/smoke_tests/feddg_ga_config.yaml",
@@ -162,40 +145,28 @@ async def test_feddg_ga(tolerance: float) -> None:
         client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_basic(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.basic_example.server",
         client_python_path="examples.basic_example.client",
         config_path="tests/smoke_tests/basic_config.yaml",
         dataset_path="examples/datasets/cifar_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_client_level_dp_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.dp_fed_examples.client_level_dp.server",
         client_python_path="examples.dp_fed_examples.client_level_dp.client",
         config_path="tests/smoke_tests/client_level_dp_config.yaml",
@@ -203,14 +174,8 @@ async def test_client_level_dp_cifar(tolerance: float) -> None:
         skip_assert_client_fl_rounds=True,
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
@@ -220,7 +185,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
     num_attempts = 2
     for attempt in range(num_attempts):
         try:
-            coro = run_smoke_test(
+            coroutine = run_smoke_test(
                 server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
                 client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
                 config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
@@ -228,7 +193,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
                 skip_assert_client_fl_rounds=True,
                 tolerance=tolerance,
             )
-            task = asyncio.create_task(coro)
+            task = asyncio.create_task(coroutine)
             await task
         except SmokeTestTimeoutError as e:
             task.cancel()
@@ -250,7 +215,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
 
 @pytest.mark.smoketest
 async def test_instance_level_dp_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.dp_fed_examples.instance_level_dp.server",
         client_python_path="examples.dp_fed_examples.instance_level_dp.client",
         config_path="tests/smoke_tests/instance_level_dp_config.yaml",
@@ -258,60 +223,42 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
         skip_assert_client_fl_rounds=True,
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_dp_scaffold(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.dp_scaffold_example.server",
         client_python_path="examples.dp_scaffold_example.client",
         config_path="tests/smoke_tests/dp_scaffold_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fedbn(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fedbn_example.server",
         client_python_path="examples.fedbn_example.client",
         config_path="tests/smoke_tests/fedbn_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fed_eval(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.federated_eval_example.server",
         client_python_path="examples.federated_eval_example.client",
         config_path="tests/smoke_tests/federated_eval_config.yaml",
@@ -320,119 +267,83 @@ async def test_fed_eval(tolerance: float) -> None:
         assert_evaluation_logs=True,
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fedper_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fedper_example.server",
         client_python_path="examples.fedper_example.client",
         config_path="tests/smoke_tests/fedper_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fedper_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fedrep_example.server",
         client_python_path="examples.fedrep_example.client",
         config_path="tests/smoke_tests/fedrep_config.yaml",
         dataset_path="examples/datasets/cifar_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_ditto_mnist() -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.ditto_example.server",
         client_python_path="examples.ditto_example.client",
         config_path="tests/smoke_tests/ditto_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_mr_mtl_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.mr_mtl_example.server",
         client_python_path="examples.mr_mtl_example.client",
         config_path="tests/smoke_tests/mr_mtl_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fenda(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fenda_example.server",
         client_python_path="examples.fenda_example.client",
         config_path="tests/smoke_tests/fenda_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fenda_ditto(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fenda_ditto_example.server",
         client_python_path="examples.fenda_ditto_example.client",
         config_path="tests/smoke_tests/fenda_ditto_config.yaml",
@@ -440,112 +351,76 @@ async def test_fenda_ditto(tolerance: float) -> None:
         checkpoint_path="examples/assets/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_perfcl(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.perfcl_example.server",
         client_python_path="examples.perfcl_example.client",
         config_path="tests/smoke_tests/perfcl_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_fl_plus_local(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.fl_plus_local_ft_example.server",
         client_python_path="examples.fl_plus_local_ft_example.client",
         config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
         dataset_path="examples/datasets/cifar_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_moon(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.moon_example.server",
         client_python_path="examples.moon_example.client",
         config_path="tests/smoke_tests/moon_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_ensemble(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.ensemble_example.server",
         client_python_path="examples.ensemble_example.client",
         config_path="tests/smoke_tests/ensemble_config.yaml",
         dataset_path="examples/datasets/mnist_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)
 
 
 @pytest.mark.smoketest
 async def test_flash(tolerance: float) -> None:
-    coro = run_smoke_test(
+    coroutine = run_smoke_test(
         server_python_path="examples.flash_example.server",
         client_python_path="examples.flash_example.client",
         config_path="tests/smoke_tests/flash_config.yaml",
         dataset_path="examples/datasets/cifar_data/",
         tolerance=tolerance,
     )
-    task = asyncio.create_task(coro)
-
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
+    task = asyncio.create_task(coroutine)
+    await try_running_test_task(task)
     assert_on_done_task(task)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -15,7 +15,7 @@ from .run_smoke_test import (
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 # Marks all test coroutineutines in this module
-pytestmark = pytest.mark.asyncio(loop_scope="function")
+pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
 async def try_running_test_task(task: asyncio.Task) -> None:

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,9 +1,10 @@
 import asyncio
 import os
+from pathlib import Path
 
 import pytest
 
-from .run_smoke_test import run_smoke_test  # load_metrics_from_file,; run_fault_tolerance_smoke_test,
+from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
 
 # from pathlib import Path
 
@@ -15,186 +16,13 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
-# clean up
-async def cleanup_test(event_loop: asyncio.AbstractEventLoop) -> None:
-    lingering_tasks = asyncio.all_tasks()
-    if lingering_tasks:
-        if not event_loop.is_running():
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
-        await asyncio.wait(lingering_tasks)
+def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoop) -> None:
+    """This function takes a done task and makes assert if a result was returned.
 
-
-# @pytest.mark.smoketest
-# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-#     checkpoint_dir = tmp_path / "checkpoints"
-#     checkpoint_dir.mkdir(exist_ok=True)
-
-#     try:
-#         server_errors, client_errors = await run_fault_tolerance_smoke_test(
-#             server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-#             client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-#             config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-#             partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             seed=42,
-#             server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-#             client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-#             intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.smoketest
-# async def test_nnunet_config_2d(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#             server_python_path="examples.nnunet_example.server",
-#             client_python_path="examples.nnunet_example.client",
-#             config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-#             dataset_path="examples/datasets/nnunet",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.smoketest
-# async def test_nnunet_config_3d(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#             server_python_path="examples.nnunet_example.server",
-#             client_python_path="examples.nnunet_example.client",
-#             config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-#             dataset_path="examples/datasets/nnunet",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.smoketest
-# async def test_scaffold(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.scaffold_example.server",
-#             client_python_path="examples.scaffold_example.client",
-#             config_path="tests/smoke_tests/scaffold_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             seed=42,
-#             server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-#             client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_apfl(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.apfl_example.server",
-#             client_python_path="examples.apfl_example.client",
-#             config_path="tests/smoke_tests/apfl_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             seed=42,
-#             server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-#             client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_feddg_ga(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.feddg_ga_example.server",
-#             client_python_path="examples.feddg_ga_example.client",
-#             config_path="tests/smoke_tests/feddg_ga_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             seed=42,
-#             server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-#             client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.smoketest
-# async def test_basic(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.basic_example.server",
-#             client_python_path="examples.basic_example.client",
-#             config_path="tests/smoke_tests/basic_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-# @pytest.mark.smoketest
-# async def test_client_level_dp_cifar(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.dp_fed_examples.client_level_dp.server",
-#             client_python_path="examples.dp_fed_examples.client_level_dp.client",
-#             config_path="tests/smoke_tests/client_level_dp_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             skip_assert_client_fl_rounds=True,
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
-
-
-@pytest.mark.smoketest
-async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
-    event_loop = asyncio.get_event_loop()
-    coro = run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
-        config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
-        dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    await task
-
+    If an exception was returned, then it fails the pytest for proper shutdown.
+    Also, if the task was cancelled, then it cleans up the cancelled tasks so the
+    next test doesn't get this hangover and fails as a result.
+    """
     try:
         e = task.exception()
         # at this point there is either an Exception or a Result and the task wasn't cancelled
@@ -205,264 +33,388 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
             assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
             assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
     except asyncio.exceptions.CancelledError:
-        print("I was cancelled", flush=True)
         if not event_loop.is_running():
-            event_loop.run_forever()  # give cancelled tasks a chance to clear
+            event_loop.run_forever()
+
+
+@pytest.mark.smoketest
+async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir(exist_ok=True)
+    coro = run_fault_tolerance_smoke_test(
+        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_nnunet_config_2d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_nnunet_config_3d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_scaffold(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.scaffold_example.server",
+        client_python_path="examples.scaffold_example.client",
+        config_path="tests/smoke_tests/scaffold_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_apfl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.apfl_example.server",
+        client_python_path="examples.apfl_example.client",
+        config_path="tests/smoke_tests/apfl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_feddg_ga(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.feddg_ga_example.server",
+        client_python_path="examples.feddg_ga_example.client",
+        config_path="tests/smoke_tests/feddg_ga_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_basic(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.basic_example.server",
+        client_python_path="examples.basic_example.client",
+        config_path="tests/smoke_tests/basic_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_client_level_dp_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.dp_fed_examples.client_level_dp.server",
+        client_python_path="examples.dp_fed_examples.client_level_dp.client",
+        config_path="tests/smoke_tests/client_level_dp_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        skip_assert_client_fl_rounds=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
+
+
+@pytest.mark.smoketest
+async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.dp_fed_examples.client_level_dp_weighted.server",
+        client_python_path="examples.dp_fed_examples.client_level_dp_weighted.client",
+        config_path="tests/smoke_tests/client_level_dp_weighted_config.yaml",
+        dataset_path="examples/datasets/breast_cancer_data/hospital_0.csv",
+        skip_assert_client_fl_rounds=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
 @pytest.mark.smoketest
 async def test_instance_level_dp_cifar(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.dp_fed_examples.instance_level_dp.server",
-            client_python_path="examples.dp_fed_examples.instance_level_dp.client",
-            config_path="tests/smoke_tests/instance_level_dp_config.yaml",
-            dataset_path="examples/datasets/cifar_data/",
-            skip_assert_client_fl_rounds=True,
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+    coro = run_smoke_test(
+        server_python_path="examples.dp_fed_examples.instance_level_dp.server",
+        client_python_path="examples.dp_fed_examples.instance_level_dp.client",
+        config_path="tests/smoke_tests/instance_level_dp_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        skip_assert_client_fl_rounds=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_dp_scaffold(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.dp_scaffold_example.server",
-#             client_python_path="examples.dp_scaffold_example.client",
-#             config_path="tests/smoke_tests/dp_scaffold_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_dp_scaffold(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.dp_scaffold_example.server",
+        client_python_path="examples.dp_scaffold_example.client",
+        config_path="tests/smoke_tests/dp_scaffold_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
 @pytest.mark.smoketest
 async def test_fedbn(tolerance: float) -> None:
-    try:
-        server_errors, client_errors = await run_smoke_test(
-            server_python_path="examples.fedbn_example.server",
-            client_python_path="examples.fedbn_example.client",
-            config_path="tests/smoke_tests/fedbn_config.yaml",
-            dataset_path="examples/datasets/mnist_data/",
-            tolerance=tolerance,
-        )
-    except Exception as e:
-        pytest.fail(f"Smoke test execution failed: {e}")
-
-    assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-    assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+    coro = run_smoke_test(
+        server_python_path="examples.fedbn_example.server",
+        client_python_path="examples.fedbn_example.client",
+        config_path="tests/smoke_tests/fedbn_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fed_eval(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.federated_eval_example.server",
-#             client_python_path="examples.federated_eval_example.client",
-#             config_path="tests/smoke_tests/federated_eval_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-#             assert_evaluation_logs=True,
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fed_eval(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.federated_eval_example.server",
+        client_python_path="examples.federated_eval_example.client",
+        config_path="tests/smoke_tests/federated_eval_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+        assert_evaluation_logs=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_mnist(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.fedper_example.server",
-#             client_python_path="examples.fedper_example.client",
-#             config_path="tests/smoke_tests/fedper_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fedper_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedper_example.server",
+        client_python_path="examples.fedper_example.client",
+        config_path="tests/smoke_tests/fedper_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_cifar(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.fedrep_example.server",
-#             client_python_path="examples.fedrep_example.client",
-#             config_path="tests/smoke_tests/fedrep_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fedper_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedrep_example.server",
+        client_python_path="examples.fedrep_example.client",
+        config_path="tests/smoke_tests/fedrep_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ditto_mnist() -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.ditto_example.server",
-#             client_python_path="examples.ditto_example.client",
-#             config_path="tests/smoke_tests/ditto_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_ditto_mnist() -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ditto_example.server",
+        client_python_path="examples.ditto_example.client",
+        config_path="tests/smoke_tests/ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_mr_mtl_mnist(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.mr_mtl_example.server",
-#             client_python_path="examples.mr_mtl_example.client",
-#             config_path="tests/smoke_tests/mr_mtl_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_mr_mtl_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.mr_mtl_example.server",
+        client_python_path="examples.mr_mtl_example.client",
+        config_path="tests/smoke_tests/mr_mtl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.fenda_example.server",
-#             client_python_path="examples.fenda_example.client",
-#             config_path="tests/smoke_tests/fenda_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fenda(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_example.server",
+        client_python_path="examples.fenda_example.client",
+        config_path="tests/smoke_tests/fenda_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda_ditto(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.fenda_ditto_example.server",
-#             client_python_path="examples.fenda_ditto_example.client",
-#             config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             checkpoint_path="examples/assets/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fenda_ditto(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_ditto_example.server",
+        client_python_path="examples.fenda_ditto_example.client",
+        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        checkpoint_path="examples/assets/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_perfcl(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.perfcl_example.server",
-#             client_python_path="examples.perfcl_example.client",
-#             config_path="tests/smoke_tests/perfcl_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_perfcl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.perfcl_example.server",
+        client_python_path="examples.perfcl_example.client",
+        config_path="tests/smoke_tests/perfcl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fl_plus_local(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.fl_plus_local_ft_example.server",
-#             client_python_path="examples.fl_plus_local_ft_example.client",
-#             config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_fl_plus_local(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fl_plus_local_ft_example.server",
+        client_python_path="examples.fl_plus_local_ft_example.client",
+        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_moon(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.moon_example.server",
-#             client_python_path="examples.moon_example.client",
-#             config_path="tests/smoke_tests/moon_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_moon(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.moon_example.server",
+        client_python_path="examples.moon_example.client",
+        config_path="tests/smoke_tests/moon_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ensemble(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.ensemble_example.server",
-#             client_python_path="examples.ensemble_example.client",
-#             config_path="tests/smoke_tests/ensemble_config.yaml",
-#             dataset_path="examples/datasets/mnist_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_ensemble(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ensemble_example.server",
+        client_python_path="examples.ensemble_example.client",
+        config_path="tests/smoke_tests/ensemble_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_flash(tolerance: float) -> None:
-#     try:
-#         server_errors, client_errors = await run_smoke_test(
-#             server_python_path="examples.flash_example.server",
-#             client_python_path="examples.flash_example.client",
-#             config_path="tests/smoke_tests/flash_config.yaml",
-#             dataset_path="examples/datasets/cifar_data/",
-#             tolerance=tolerance,
-#         )
-#     except Exception as e:
-#         pytest.fail(f"Smoke test execution failed: {e}")
-
-#     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
-#     assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
+@pytest.mark.smoketest
+async def test_flash(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.flash_example.server",
+        client_python_path="examples.flash_example.client",
+        config_path="tests/smoke_tests/flash_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    await task
+    assert_on_done_task(task, event_loop)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -15,6 +15,16 @@ IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 
+# clean up
+async def cleanup_test(event_loop: asyncio.AbstractEventLoop) -> None:
+    lingering_tasks = asyncio.all_tasks()
+    if lingering_tasks:
+        if not event_loop.is_running():
+            # these are cancelled tasks and need to be cleared up before next test
+            event_loop.run_forever()
+        await asyncio.wait(lingering_tasks)
+
+
 # @pytest.mark.smoketest
 # async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
 #     checkpoint_dir = tmp_path / "checkpoints"
@@ -184,11 +194,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -208,11 +214,7 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -231,11 +233,7 @@ async def test_dp_scaffold(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -254,11 +252,7 @@ async def test_fedbn(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -279,11 +273,7 @@ async def test_fed_eval(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"
@@ -302,11 +292,7 @@ async def test_fedper_mnist(tolerance: float) -> None:
             tolerance=tolerance,
         )
     except Exception as e:
-        # proper clean up of cancelled tasks before stopping event_loop
-        lingering_tasks = asyncio.all_tasks()
-        if lingering_tasks:
-            # these are cancelled tasks and need to be cleared up before next test
-            event_loop.run_forever()
+        await cleanup_test(event_loop)
         pytest.fail(f"Smoke test execution failed: {e}")
 
     assert len(server_errors) == 0, f"Server metrics check failed. Errors: {server_errors}"

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -8,9 +8,11 @@ from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_te
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
+# Marks all test coroutines in this module
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir(exist_ok=True)
@@ -36,7 +38,6 @@ async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> No
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_nnunet_config_2d(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
@@ -54,7 +55,6 @@ async def test_nnunet_config_2d(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_nnunet_config_3d(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(  # By default will use Task04_Hippocampus Dataset
@@ -72,7 +72,6 @@ async def test_nnunet_config_3d(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_scaffold(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -94,7 +93,6 @@ async def test_scaffold(tolerance: float) -> None:
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_apfl(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -116,7 +114,6 @@ async def test_apfl(tolerance: float) -> None:
 
 @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_feddg_ga(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -137,7 +134,6 @@ async def test_feddg_ga(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_basic(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -155,7 +151,6 @@ async def test_basic(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_client_level_dp_cifar(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -174,7 +169,6 @@ async def test_client_level_dp_cifar(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -193,7 +187,6 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_instance_level_dp_cifar(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -212,7 +205,6 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_dp_scaffold(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -230,7 +222,6 @@ async def test_dp_scaffold(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fedbn(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -248,7 +239,6 @@ async def test_fedbn(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fed_eval(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -268,7 +258,6 @@ async def test_fed_eval(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fedper_mnist(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -286,7 +275,6 @@ async def test_fedper_mnist(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fedper_cifar(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -304,7 +292,6 @@ async def test_fedper_cifar(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_ditto_mnist() -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -321,7 +308,6 @@ async def test_ditto_mnist() -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_mr_mtl_mnist(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -339,7 +325,6 @@ async def test_mr_mtl_mnist(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fenda(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -357,7 +342,6 @@ async def test_fenda(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fenda_ditto(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -376,7 +360,6 @@ async def test_fenda_ditto(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_perfcl(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -394,7 +377,6 @@ async def test_perfcl(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_fl_plus_local(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -412,7 +394,6 @@ async def test_fl_plus_local(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_moon(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -430,7 +411,6 @@ async def test_moon(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_ensemble(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(
@@ -448,7 +428,6 @@ async def test_ensemble(tolerance: float) -> None:
 
 
 @pytest.mark.smoketest
-@pytest.mark.asyncio()
 async def test_flash(tolerance: float) -> None:
     try:
         server_errors, client_errors = await run_smoke_test(

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -52,7 +52,7 @@ async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> No
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -72,7 +72,7 @@ async def test_nnunet_config_2d(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -92,7 +92,7 @@ async def test_nnunet_config_3d(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -115,7 +115,7 @@ async def test_scaffold(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -139,7 +139,7 @@ async def test_apfl(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -163,7 +163,7 @@ async def test_feddg_ga(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -183,7 +183,7 @@ async def test_basic(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -204,7 +204,7 @@ async def test_client_level_dp_cifar(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -226,7 +226,7 @@ async def test_client_level_dp_breast_cancer(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -247,7 +247,7 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -267,7 +267,7 @@ async def test_dp_scaffold(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -287,7 +287,7 @@ async def test_fedbn(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -309,7 +309,7 @@ async def test_fed_eval(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -329,7 +329,7 @@ async def test_fedper_mnist(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -349,7 +349,7 @@ async def test_fedper_cifar(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -368,7 +368,7 @@ async def test_ditto_mnist() -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -388,7 +388,7 @@ async def test_mr_mtl_mnist(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -408,7 +408,7 @@ async def test_fenda(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -429,7 +429,7 @@ async def test_fenda_ditto(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -449,7 +449,7 @@ async def test_perfcl(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -469,7 +469,7 @@ async def test_fl_plus_local(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -489,7 +489,7 @@ async def test_moon(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -509,7 +509,7 @@ async def test_ensemble(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)
 
@@ -529,6 +529,6 @@ async def test_flash(tolerance: float) -> None:
         await task
     except Exception as e:
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
         pytest.fail(f"Smoke test failed due to error. {e}")
     assert_on_done_task(task, event_loop)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
-from pathlib import Path
 
 import pytest
 
-from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
+# from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
+from .run_smoke_test import run_smoke_test
+
+# from pathlib import Path
+
 
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
@@ -30,183 +33,183 @@ def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoo
         assert len(client_errors) == 0, f"Client metrics check failed. Errors: {client_errors}"
 
 
-@pytest.mark.smoketest
-async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-    checkpoint_dir = tmp_path / "checkpoints"
-    checkpoint_dir.mkdir(exist_ok=True)
-    coro = run_fault_tolerance_smoke_test(
-        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+#     checkpoint_dir = tmp_path / "checkpoints"
+#     checkpoint_dir.mkdir(exist_ok=True)
+#     coro = run_fault_tolerance_smoke_test(
+#         server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+#         client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+#         config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+#         partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+#         intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_nnunet_config_2d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_nnunet_config_2d(tolerance: float) -> None:
+#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#         server_python_path="examples.nnunet_example.server",
+#         client_python_path="examples.nnunet_example.client",
+#         config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+#         dataset_path="examples/datasets/nnunet",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_nnunet_config_3d(tolerance: float) -> None:
-    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-        server_python_path="examples.nnunet_example.server",
-        client_python_path="examples.nnunet_example.client",
-        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-        dataset_path="examples/datasets/nnunet",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_nnunet_config_3d(tolerance: float) -> None:
+#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+#         server_python_path="examples.nnunet_example.server",
+#         client_python_path="examples.nnunet_example.client",
+#         config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+#         dataset_path="examples/datasets/nnunet",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_scaffold(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.scaffold_example.server",
-        client_python_path="examples.scaffold_example.client",
-        config_path="tests/smoke_tests/scaffold_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_scaffold(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.scaffold_example.server",
+#         client_python_path="examples.scaffold_example.client",
+#         config_path="tests/smoke_tests/scaffold_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_apfl(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.apfl_example.server",
-        client_python_path="examples.apfl_example.client",
-        config_path="tests/smoke_tests/apfl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_apfl(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.apfl_example.server",
+#         client_python_path="examples.apfl_example.client",
+#         config_path="tests/smoke_tests/apfl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-@pytest.mark.smoketest
-async def test_feddg_ga(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.feddg_ga_example.server",
-        client_python_path="examples.feddg_ga_example.client",
-        config_path="tests/smoke_tests/feddg_ga_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        seed=42,
-        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+# @pytest.mark.smoketest
+# async def test_feddg_ga(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.feddg_ga_example.server",
+#         client_python_path="examples.feddg_ga_example.client",
+#         config_path="tests/smoke_tests/feddg_ga_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         seed=42,
+#         server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+#         client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_basic(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.basic_example.server",
-        client_python_path="examples.basic_example.client",
-        config_path="tests/smoke_tests/basic_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_basic(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.basic_example.server",
+#         client_python_path="examples.basic_example.client",
+#         config_path="tests/smoke_tests/basic_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_client_level_dp_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.dp_fed_examples.client_level_dp.server",
-        client_python_path="examples.dp_fed_examples.client_level_dp.client",
-        config_path="tests/smoke_tests/client_level_dp_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        skip_assert_client_fl_rounds=True,
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_client_level_dp_cifar(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.dp_fed_examples.client_level_dp.server",
+#         client_python_path="examples.dp_fed_examples.client_level_dp.client",
+#         config_path="tests/smoke_tests/client_level_dp_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         skip_assert_client_fl_rounds=True,
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
 @pytest.mark.smoketest
@@ -272,263 +275,263 @@ async def test_dp_scaffold(tolerance: float) -> None:
     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fedbn(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fedbn_example.server",
-        client_python_path="examples.fedbn_example.client",
-        config_path="tests/smoke_tests/fedbn_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fedbn(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fedbn_example.server",
+#         client_python_path="examples.fedbn_example.client",
+#         config_path="tests/smoke_tests/fedbn_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fed_eval(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.federated_eval_example.server",
-        client_python_path="examples.federated_eval_example.client",
-        config_path="tests/smoke_tests/federated_eval_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-        assert_evaluation_logs=True,
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fed_eval(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.federated_eval_example.server",
+#         client_python_path="examples.federated_eval_example.client",
+#         config_path="tests/smoke_tests/federated_eval_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+#         assert_evaluation_logs=True,
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fedper_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fedper_example.server",
-        client_python_path="examples.fedper_example.client",
-        config_path="tests/smoke_tests/fedper_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fedper_mnist(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fedper_example.server",
+#         client_python_path="examples.fedper_example.client",
+#         config_path="tests/smoke_tests/fedper_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fedper_cifar(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fedrep_example.server",
-        client_python_path="examples.fedrep_example.client",
-        config_path="tests/smoke_tests/fedrep_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fedper_cifar(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fedrep_example.server",
+#         client_python_path="examples.fedrep_example.client",
+#         config_path="tests/smoke_tests/fedrep_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_ditto_mnist() -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.ditto_example.server",
-        client_python_path="examples.ditto_example.client",
-        config_path="tests/smoke_tests/ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_ditto_mnist() -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.ditto_example.server",
+#         client_python_path="examples.ditto_example.client",
+#         config_path="tests/smoke_tests/ditto_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_mr_mtl_mnist(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.mr_mtl_example.server",
-        client_python_path="examples.mr_mtl_example.client",
-        config_path="tests/smoke_tests/mr_mtl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_mr_mtl_mnist(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.mr_mtl_example.server",
+#         client_python_path="examples.mr_mtl_example.client",
+#         config_path="tests/smoke_tests/mr_mtl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fenda(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fenda_example.server",
-        client_python_path="examples.fenda_example.client",
-        config_path="tests/smoke_tests/fenda_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fenda(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fenda_example.server",
+#         client_python_path="examples.fenda_example.client",
+#         config_path="tests/smoke_tests/fenda_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fenda_ditto(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fenda_ditto_example.server",
-        client_python_path="examples.fenda_ditto_example.client",
-        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        checkpoint_path="examples/assets/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fenda_ditto(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fenda_ditto_example.server",
+#         client_python_path="examples.fenda_ditto_example.client",
+#         config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         checkpoint_path="examples/assets/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_perfcl(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.perfcl_example.server",
-        client_python_path="examples.perfcl_example.client",
-        config_path="tests/smoke_tests/perfcl_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_perfcl(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.perfcl_example.server",
+#         client_python_path="examples.perfcl_example.client",
+#         config_path="tests/smoke_tests/perfcl_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_fl_plus_local(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.fl_plus_local_ft_example.server",
-        client_python_path="examples.fl_plus_local_ft_example.client",
-        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_fl_plus_local(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.fl_plus_local_ft_example.server",
+#         client_python_path="examples.fl_plus_local_ft_example.client",
+#         config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_moon(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.moon_example.server",
-        client_python_path="examples.moon_example.client",
-        config_path="tests/smoke_tests/moon_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_moon(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.moon_example.server",
+#         client_python_path="examples.moon_example.client",
+#         config_path="tests/smoke_tests/moon_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_ensemble(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.ensemble_example.server",
-        client_python_path="examples.ensemble_example.client",
-        config_path="tests/smoke_tests/ensemble_config.yaml",
-        dataset_path="examples/datasets/mnist_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_ensemble(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.ensemble_example.server",
+#         client_python_path="examples.ensemble_example.client",
+#         config_path="tests/smoke_tests/ensemble_config.yaml",
+#         dataset_path="examples/datasets/mnist_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)
 
 
-@pytest.mark.smoketest
-async def test_flash(tolerance: float) -> None:
-    coro = run_smoke_test(
-        server_python_path="examples.flash_example.server",
-        client_python_path="examples.flash_example.client",
-        config_path="tests/smoke_tests/flash_config.yaml",
-        dataset_path="examples/datasets/cifar_data/",
-        tolerance=tolerance,
-    )
-    task = asyncio.create_task(coro)
-    event_loop = asyncio.get_event_loop()
-    try:
-        await task
-    except Exception as e:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
-        pytest.fail(f"Smoke test failed due to error. {e}")
-    assert_on_done_task(task, event_loop)
+# @pytest.mark.smoketest
+# async def test_flash(tolerance: float) -> None:
+#     coro = run_smoke_test(
+#         server_python_path="examples.flash_example.server",
+#         client_python_path="examples.flash_example.client",
+#         config_path="tests/smoke_tests/flash_config.yaml",
+#         dataset_path="examples/datasets/cifar_data/",
+#         tolerance=tolerance,
+#     )
+#     task = asyncio.create_task(coro)
+#     event_loop = asyncio.get_event_loop()
+#     try:
+#         await task
+#     except Exception as e:
+#         task.cancel()
+#         await asyncio.gather(task, return_exceptions=True)  # allow time to clean up cancelled task
+#         pytest.fail(f"Smoke test failed due to error. {e}")
+#     assert_on_done_task(task, event_loop)

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -1,16 +1,10 @@
 import asyncio
 import os
+from pathlib import Path
 
 import pytest
 
-# from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
-from .run_smoke_test import run_smoke_test
-
-# from pathlib import Path
-
-
-# from pathlib import Path
-
+from .run_smoke_test import load_metrics_from_file, run_fault_tolerance_smoke_test, run_smoke_test
 
 # skip some tests that currently fail if running locallly
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
@@ -48,167 +42,175 @@ def assert_on_done_task(task: asyncio.Task, event_loop: asyncio.AbstractEventLoo
         cleanup_cancelled_tasks(event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
-#     checkpoint_dir = tmp_path / "checkpoints"
-#     checkpoint_dir.mkdir(exist_ok=True)
-#     coro = run_fault_tolerance_smoke_test(
-#         server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
-#         client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
-#         config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
-#         partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
-#         intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_basic_server_client_cifar(tolerance: float, tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir(exist_ok=True)
+    coro = run_fault_tolerance_smoke_test(
+        server_python_path="tests.smoke_tests.load_from_checkpoint_example.server",
+        client_python_path="tests.smoke_tests.load_from_checkpoint_example.client",
+        config_path="tests/smoke_tests/load_from_checkpoint_example/config.yaml",
+        partial_config_path="tests/smoke_tests/load_from_checkpoint_example/partial_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/basic_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/basic_client_metrics.json"),
+        intermediate_checkpoint_dir=checkpoint_dir.as_posix(),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_nnunet_config_2d(tolerance: float) -> None:
-#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#         server_python_path="examples.nnunet_example.server",
-#         client_python_path="examples.nnunet_example.client",
-#         config_path="tests/smoke_tests/nnunet_config_2d.yaml",
-#         dataset_path="examples/datasets/nnunet",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_nnunet_config_2d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_2d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_nnunet_config_3d(tolerance: float) -> None:
-#     coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
-#         server_python_path="examples.nnunet_example.server",
-#         client_python_path="examples.nnunet_example.client",
-#         config_path="tests/smoke_tests/nnunet_config_3d.yaml",
-#         dataset_path="examples/datasets/nnunet",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_nnunet_config_3d(tolerance: float) -> None:
+    coro = run_smoke_test(  # By default will use Task04_Hippocampus Dataset
+        server_python_path="examples.nnunet_example.server",
+        client_python_path="examples.nnunet_example.client",
+        config_path="tests/smoke_tests/nnunet_config_3d.yaml",
+        dataset_path="examples/datasets/nnunet",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_scaffold(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.scaffold_example.server",
-#         client_python_path="examples.scaffold_example.client",
-#         config_path="tests/smoke_tests/scaffold_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_scaffold(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.scaffold_example.server",
+        client_python_path="examples.scaffold_example.client",
+        config_path="tests/smoke_tests/scaffold_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/scaffold_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_apfl(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.apfl_example.server",
-#         client_python_path="examples.apfl_example.client",
-#         config_path="tests/smoke_tests/apfl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_apfl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.apfl_example.server",
+        client_python_path="examples.apfl_example.client",
+        config_path="tests/smoke_tests/apfl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/apfl_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/apfl_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
-# @pytest.mark.smoketest
-# async def test_feddg_ga(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.feddg_ga_example.server",
-#         client_python_path="examples.feddg_ga_example.client",
-#         config_path="tests/smoke_tests/feddg_ga_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         seed=42,
-#         server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
-#         client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.skipif(not IN_GITHUB_ACTIONS, reason="Test doesn't work locally.")
+@pytest.mark.smoketest
+async def test_feddg_ga(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.feddg_ga_example.server",
+        client_python_path="examples.feddg_ga_example.client",
+        config_path="tests/smoke_tests/feddg_ga_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        seed=42,
+        server_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_server_metrics.json"),
+        client_metrics=load_metrics_from_file("tests/smoke_tests/feddg_ga_client_metrics.json"),
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_basic(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.basic_example.server",
-#         client_python_path="examples.basic_example.client",
-#         config_path="tests/smoke_tests/basic_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_basic(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.basic_example.server",
+        client_python_path="examples.basic_example.client",
+        config_path="tests/smoke_tests/basic_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_client_level_dp_cifar(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.dp_fed_examples.client_level_dp.server",
-#         client_python_path="examples.dp_fed_examples.client_level_dp.client",
-#         config_path="tests/smoke_tests/client_level_dp_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         skip_assert_client_fl_rounds=True,
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_client_level_dp_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.dp_fed_examples.client_level_dp.server",
+        client_python_path="examples.dp_fed_examples.client_level_dp.client",
+        config_path="tests/smoke_tests/client_level_dp_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        skip_assert_client_fl_rounds=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
 @pytest.mark.smoketest
@@ -246,6 +248,7 @@ async def test_instance_level_dp_cifar(tolerance: float) -> None:
     try:
         await task
     except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
         pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
@@ -264,6 +267,7 @@ async def test_dp_scaffold(tolerance: float) -> None:
     try:
         await task
     except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
         pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
@@ -282,223 +286,236 @@ async def test_fedbn(tolerance: float) -> None:
     try:
         await task
     except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
         pytest.fail("Smoke test failed due to Timeout Error.")
     assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fed_eval(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.federated_eval_example.server",
-#         client_python_path="examples.federated_eval_example.client",
-#         config_path="tests/smoke_tests/federated_eval_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
-#         assert_evaluation_logs=True,
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fed_eval(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.federated_eval_example.server",
+        client_python_path="examples.federated_eval_example.client",
+        config_path="tests/smoke_tests/federated_eval_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        checkpoint_path="examples/assets/fed_eval_example/best_checkpoint_fczjmljm.pkl",
+        assert_evaluation_logs=True,
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_mnist(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fedper_example.server",
-#         client_python_path="examples.fedper_example.client",
-#         config_path="tests/smoke_tests/fedper_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fedper_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedper_example.server",
+        client_python_path="examples.fedper_example.client",
+        config_path="tests/smoke_tests/fedper_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fedper_cifar(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fedrep_example.server",
-#         client_python_path="examples.fedrep_example.client",
-#         config_path="tests/smoke_tests/fedrep_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fedper_cifar(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fedrep_example.server",
+        client_python_path="examples.fedrep_example.client",
+        config_path="tests/smoke_tests/fedrep_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ditto_mnist() -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.ditto_example.server",
-#         client_python_path="examples.ditto_example.client",
-#         config_path="tests/smoke_tests/ditto_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_ditto_mnist() -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ditto_example.server",
+        client_python_path="examples.ditto_example.client",
+        config_path="tests/smoke_tests/ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_mr_mtl_mnist(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.mr_mtl_example.server",
-#         client_python_path="examples.mr_mtl_example.client",
-#         config_path="tests/smoke_tests/mr_mtl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_mr_mtl_mnist(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.mr_mtl_example.server",
+        client_python_path="examples.mr_mtl_example.client",
+        config_path="tests/smoke_tests/mr_mtl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fenda_example.server",
-#         client_python_path="examples.fenda_example.client",
-#         config_path="tests/smoke_tests/fenda_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fenda(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_example.server",
+        client_python_path="examples.fenda_example.client",
+        config_path="tests/smoke_tests/fenda_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fenda_ditto(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fenda_ditto_example.server",
-#         client_python_path="examples.fenda_ditto_example.client",
-#         config_path="tests/smoke_tests/fenda_ditto_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         checkpoint_path="examples/assets/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fenda_ditto(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fenda_ditto_example.server",
+        client_python_path="examples.fenda_ditto_example.client",
+        config_path="tests/smoke_tests/fenda_ditto_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        checkpoint_path="examples/assets/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_perfcl(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.perfcl_example.server",
-#         client_python_path="examples.perfcl_example.client",
-#         config_path="tests/smoke_tests/perfcl_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_perfcl(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.perfcl_example.server",
+        client_python_path="examples.perfcl_example.client",
+        config_path="tests/smoke_tests/perfcl_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_fl_plus_local(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.fl_plus_local_ft_example.server",
-#         client_python_path="examples.fl_plus_local_ft_example.client",
-#         config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_fl_plus_local(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.fl_plus_local_ft_example.server",
+        client_python_path="examples.fl_plus_local_ft_example.client",
+        config_path="tests/smoke_tests/fl_plus_local_ft_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_moon(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.moon_example.server",
-#         client_python_path="examples.moon_example.client",
-#         config_path="tests/smoke_tests/moon_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_moon(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.moon_example.server",
+        client_python_path="examples.moon_example.client",
+        config_path="tests/smoke_tests/moon_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_ensemble(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.ensemble_example.server",
-#         client_python_path="examples.ensemble_example.client",
-#         config_path="tests/smoke_tests/ensemble_config.yaml",
-#         dataset_path="examples/datasets/mnist_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_ensemble(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.ensemble_example.server",
+        client_python_path="examples.ensemble_example.client",
+        config_path="tests/smoke_tests/ensemble_config.yaml",
+        dataset_path="examples/datasets/mnist_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)
 
 
-# @pytest.mark.smoketest
-# async def test_flash(tolerance: float) -> None:
-#     coro = run_smoke_test(
-#         server_python_path="examples.flash_example.server",
-#         client_python_path="examples.flash_example.client",
-#         config_path="tests/smoke_tests/flash_config.yaml",
-#         dataset_path="examples/datasets/cifar_data/",
-#         tolerance=tolerance,
-#     )
-#     task = asyncio.create_task(coro)
-#     event_loop = asyncio.get_event_loop()
-#     try:
-#         await task
-#     except asyncio.exceptions.TimeoutError:
-#         pytest.fail("Smoke test failed due to Timeout Error.")
-#     assert_on_done_task(task, event_loop)
+@pytest.mark.smoketest
+async def test_flash(tolerance: float) -> None:
+    coro = run_smoke_test(
+        server_python_path="examples.flash_example.server",
+        client_python_path="examples.flash_example.client",
+        config_path="tests/smoke_tests/flash_config.yaml",
+        dataset_path="examples/datasets/cifar_data/",
+        tolerance=tolerance,
+    )
+    task = asyncio.create_task(coro)
+    event_loop = asyncio.get_event_loop()
+    try:
+        await task
+    except asyncio.exceptions.TimeoutError:
+        cleanup_cancelled_tasks(event_loop)
+        pytest.fail("Smoke test failed due to Timeout Error.")
+    assert_on_done_task(task, event_loop)


### PR DESCRIPTION
# PR Type
Fix

# Short Description

**THIS PR BROUGHT THE SMOKE**  💨 💨 💨
![image](https://github.com/user-attachments/assets/488abe46-eca2-4f91-84f0-5885d1c582fa)



This PR addresses an issue with our smoke tests where if one fails (the usual culprit being `test_client_level_dp_breast_cancer`) then it torpedos all of the remaining tests that follow it. Moreover, the error logs of the job looked super scary!

To address this issue, this PR:

1. Ensures that each test explicitly fails if an `Exception` is encountered during the test.
2. Aims to ensure that any lingering cancelled tasks in the event of unexpected test failure (due to Timeout or another reason) are cleared. The reason why we saw the domino effect is because if these cancelled tasks are not cleared, then they will be the next time an event loop starts running. In our case the next test would run the event loop but the hangover cancelled tasks would take precedence and then "stop" the loop and thus cause the next test to crash.

In addition to the above:
- We also move the asserts used in `run_smoke_test` to the actual testing module `test_smoke_test.py` and "within" the test themselves directly. This is mostly for hygiene to follow typical pytest conventions which makes it easier to see why a test might fail and explicitly make it fail if an exception is raised.
- Also the progress of these smoke tests can now actually be viewed in the logs of job as its running.
![image](https://github.com/user-attachments/assets/5f3afac4-e4e7-44b7-aa53-36c8d3ff2928)

NOTE:
If `test_client_level_dp_breast_cancer` fails, it will still fail the overall smoke test job which mean's we'll need to run all of the tests even passing ones again. In another PR we could mark this test with something like "flaky" and then create a separate job for flaky tests and so re-running these would be less time consuming.

# Tests Added

N/A