### PR TITLE
Fix local plans

### DIFF
--- a/examples/nnunet_example/server.py
+++ b/examples/nnunet_example/server.py
@@ -4,9 +4,9 @@ import pickle
 from functools import partial
 from pathlib import Path
 
-import yaml
 import flwr as fl
 import torch
+import yaml
 from flwr.common.parameter import ndarrays_to_parameters
 from flwr.common.typing import Config
 from flwr.server.client_manager import SimpleClientManager

--- a/examples/nnunet_example/server.py
+++ b/examples/nnunet_example/server.py
@@ -1,18 +1,10 @@
 import argparse
 import json
 import pickle
-import warnings
 from functools import partial
 from pathlib import Path
 
 import yaml
-
-with warnings.catch_warnings():
-    # Silence deprecation warnings from sentry sdk due to flwr and wandb
-    # https://github.com/adap/flower/issues/4086
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    import wandb  # noqa: F401
-
 import flwr as fl
 import torch
 from flwr.common.parameter import ndarrays_to_parameters

--- a/fl4health/checkpointing/opacus_checkpointer.py
+++ b/fl4health/checkpointing/opacus_checkpointer.py
@@ -1,13 +1,21 @@
 import pickle
-from logging import INFO
+from logging import INFO, getLogger
 from typing import Any
+
 
 import torch.nn as nn
 from flwr.common.logger import log
 from flwr.common.typing import Scalar
+
 from opacus import GradSampleModule
 
 from fl4health.checkpointing.checkpointer import FunctionTorchModuleCheckpointer
+
+# It seems like the opacus package adds a handler to the root logger which causes double logs.
+# By clearing handlers on the root logger we prevent these double logs whilst also allowing the flwr logger to
+# propagate its logs to the root logger.
+root_logger = getLogger()
+root_logger.handlers.clear()
 
 
 class OpacusCheckpointer(FunctionTorchModuleCheckpointer):
@@ -27,9 +35,9 @@ class OpacusCheckpointer(FunctionTorchModuleCheckpointer):
             loss (float): Loss value associated with the model to be used in checkpointing decisions.
             metrics (dict[str, Scalar]): Metrics associated with the model to be used in checkpointing decisions.
         """
-        assert isinstance(
-            model, GradSampleModule
-        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        assert isinstance(model, GradSampleModule), (
+            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        )
         comparison_score = self.checkpoint_score_function(loss, metrics)
         if self._should_checkpoint(comparison_score):
             log(
@@ -119,9 +127,9 @@ class LatestOpacusCheckpointer(OpacusCheckpointer):
         super().__init__(checkpoint_dir, checkpoint_name, latest_score_function, False)
 
     def maybe_checkpoint(self, model: GradSampleModule, loss: float, _: dict[str, Scalar]) -> None:
-        assert isinstance(
-            model, GradSampleModule
-        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        assert isinstance(model, GradSampleModule), (
+            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        )
         # Always checkpoint the latest model
         log(INFO, "Saving latest checkpoint with LatestTorchCheckpointer")
         self._extract_and_save_state(model)
@@ -149,9 +157,9 @@ class BestLossOpacusCheckpointer(OpacusCheckpointer):
         )
 
     def maybe_checkpoint(self, model: GradSampleModule, loss: float, metrics: dict[str, Scalar]) -> None:
-        assert isinstance(
-            model, GradSampleModule
-        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        assert isinstance(model, GradSampleModule), (
+            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
+        )
         # First we use the provided scoring function to produce a score
         comparison_score = self.checkpoint_score_function(loss, metrics)
         if self._should_checkpoint(comparison_score):

--- a/fl4health/checkpointing/opacus_checkpointer.py
+++ b/fl4health/checkpointing/opacus_checkpointer.py
@@ -2,11 +2,9 @@ import pickle
 from logging import INFO, getLogger
 from typing import Any
 
-
 import torch.nn as nn
 from flwr.common.logger import log
 from flwr.common.typing import Scalar
-
 from opacus import GradSampleModule
 
 from fl4health.checkpointing.checkpointer import FunctionTorchModuleCheckpointer
@@ -35,9 +33,9 @@ class OpacusCheckpointer(FunctionTorchModuleCheckpointer):
             loss (float): Loss value associated with the model to be used in checkpointing decisions.
             metrics (dict[str, Scalar]): Metrics associated with the model to be used in checkpointing decisions.
         """
-        assert isinstance(model, GradSampleModule), (
-            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
-        )
+        assert isinstance(
+            model, GradSampleModule
+        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
         comparison_score = self.checkpoint_score_function(loss, metrics)
         if self._should_checkpoint(comparison_score):
             log(
@@ -127,9 +125,9 @@ class LatestOpacusCheckpointer(OpacusCheckpointer):
         super().__init__(checkpoint_dir, checkpoint_name, latest_score_function, False)
 
     def maybe_checkpoint(self, model: GradSampleModule, loss: float, _: dict[str, Scalar]) -> None:
-        assert isinstance(model, GradSampleModule), (
-            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
-        )
+        assert isinstance(
+            model, GradSampleModule
+        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
         # Always checkpoint the latest model
         log(INFO, "Saving latest checkpoint with LatestTorchCheckpointer")
         self._extract_and_save_state(model)
@@ -157,9 +155,9 @@ class BestLossOpacusCheckpointer(OpacusCheckpointer):
         )
 
     def maybe_checkpoint(self, model: GradSampleModule, loss: float, metrics: dict[str, Scalar]) -> None:
-        assert isinstance(model, GradSampleModule), (
-            f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
-        )
+        assert isinstance(
+            model, GradSampleModule
+        ), f"Model is of type: {type(model)}. This checkpointer need only be used to checkpoint Opacus modules"
         # First we use the provided scoring function to produce a score
         comparison_score = self.checkpoint_score_function(loss, metrics)
         if self._should_checkpoint(comparison_score):

--- a/fl4health/checkpointing/server_module.py
+++ b/fl4health/checkpointing/server_module.py
@@ -135,9 +135,9 @@ class BaseServerCheckpointAndStateModule:
             checkpointed.
         """
         assert self.model is not None, "Hydrate model for checkpoint called but self.model is None"
-        assert (
-            self.parameter_exchanger is not None
-        ), "Hydrate model for checkpoint called but self.parameter_exchanger is None"
+        assert self.parameter_exchanger is not None, (
+            "Hydrate model for checkpoint called but self.parameter_exchanger is None"
+        )
         model_ndarrays = parameters_to_ndarrays(server_parameters)
         self.parameter_exchanger.pull_parameters(model_ndarrays, self.model)
 
@@ -194,7 +194,6 @@ class BaseServerCheckpointAndStateModule:
         """
         if self.state_checkpointer is not None:
             if self.state_checkpointer.checkpoint_exists(state_checkpoint_name):
-
                 return self.state_checkpointer.load_checkpoint(state_checkpoint_name)
             else:
                 log(INFO, "State checkpointer is defined but no state checkpoint exists.")
@@ -236,9 +235,9 @@ class PackingServerCheckpointAndAndStateModule(BaseServerCheckpointAndStateModul
                 checkpointer will save much more than just the model being trained. Defaults to None.
         """
         if parameter_exchanger is not None:
-            assert isinstance(
-                parameter_exchanger, FullParameterExchangerWithPacking
-            ), "Parameter exchanger must be of based type FullParameterExchangerWithPacking"
+            assert isinstance(parameter_exchanger, FullParameterExchangerWithPacking), (
+                "Parameter exchanger must be of based type FullParameterExchangerWithPacking"
+            )
         super().__init__(model, parameter_exchanger, model_checkpointers, state_checkpointer)
 
     def _hydrate_model_for_checkpointing(self, server_parameters: Parameters) -> None:
@@ -258,9 +257,9 @@ class PackingServerCheckpointAndAndStateModule(BaseServerCheckpointAndStateModul
             checkpointed.
         """
         assert self.model is not None, "Hydrate model for checkpoint called but self.model is None"
-        assert (
-            self.parameter_exchanger is not None
-        ), "Hydrate model for checkpoint called but self.parameter_exchanger is None"
+        assert self.parameter_exchanger is not None, (
+            "Hydrate model for checkpoint called but self.parameter_exchanger is None"
+        )
         packed_parameters = parameters_to_ndarrays(server_parameters)
         assert isinstance(self.parameter_exchanger, FullParameterExchangerWithPacking)
         # Use the unpacking function of the parameter exchange to handle extraction of model parameters
@@ -483,9 +482,9 @@ class OpacusServerCheckpointAndStateModule(BaseServerCheckpointAndStateModule):
         """
         if self.model_checkpointers is not None:
             for checkpointer in self.model_checkpointers:
-                assert isinstance(
-                    checkpointer, OpacusCheckpointer
-                ), "Provided checkpointers must have base class OpacusCheckpointer"
+                assert isinstance(checkpointer, OpacusCheckpointer), (
+                    "Provided checkpointers must have base class OpacusCheckpointer"
+                )
 
 
 class NnUnetServerCheckpointAndStateModule(BaseServerCheckpointAndStateModule):
@@ -572,6 +571,6 @@ class DpScaffoldServerCheckpointAndStateModule(ScaffoldServerCheckpointAndStateM
         """
         if self.model_checkpointers is not None:
             for checkpointer in self.model_checkpointers:
-                assert isinstance(
-                    checkpointer, OpacusCheckpointer
-                ), "Provided checkpointers must have base class OpacusCheckpointer"
+                assert isinstance(checkpointer, OpacusCheckpointer), (
+                    "Provided checkpointers must have base class OpacusCheckpointer"
+                )

--- a/fl4health/checkpointing/server_module.py
+++ b/fl4health/checkpointing/server_module.py
@@ -135,9 +135,9 @@ class BaseServerCheckpointAndStateModule:
             checkpointed.
         """
         assert self.model is not None, "Hydrate model for checkpoint called but self.model is None"
-        assert self.parameter_exchanger is not None, (
-            "Hydrate model for checkpoint called but self.parameter_exchanger is None"
-        )
+        assert (
+            self.parameter_exchanger is not None
+        ), "Hydrate model for checkpoint called but self.parameter_exchanger is None"
         model_ndarrays = parameters_to_ndarrays(server_parameters)
         self.parameter_exchanger.pull_parameters(model_ndarrays, self.model)
 
@@ -235,9 +235,9 @@ class PackingServerCheckpointAndAndStateModule(BaseServerCheckpointAndStateModul
                 checkpointer will save much more than just the model being trained. Defaults to None.
         """
         if parameter_exchanger is not None:
-            assert isinstance(parameter_exchanger, FullParameterExchangerWithPacking), (
-                "Parameter exchanger must be of based type FullParameterExchangerWithPacking"
-            )
+            assert isinstance(
+                parameter_exchanger, FullParameterExchangerWithPacking
+            ), "Parameter exchanger must be of based type FullParameterExchangerWithPacking"
         super().__init__(model, parameter_exchanger, model_checkpointers, state_checkpointer)
 
     def _hydrate_model_for_checkpointing(self, server_parameters: Parameters) -> None:
@@ -257,9 +257,9 @@ class PackingServerCheckpointAndAndStateModule(BaseServerCheckpointAndStateModul
             checkpointed.
         """
         assert self.model is not None, "Hydrate model for checkpoint called but self.model is None"
-        assert self.parameter_exchanger is not None, (
-            "Hydrate model for checkpoint called but self.parameter_exchanger is None"
-        )
+        assert (
+            self.parameter_exchanger is not None
+        ), "Hydrate model for checkpoint called but self.parameter_exchanger is None"
         packed_parameters = parameters_to_ndarrays(server_parameters)
         assert isinstance(self.parameter_exchanger, FullParameterExchangerWithPacking)
         # Use the unpacking function of the parameter exchange to handle extraction of model parameters
@@ -482,9 +482,9 @@ class OpacusServerCheckpointAndStateModule(BaseServerCheckpointAndStateModule):
         """
         if self.model_checkpointers is not None:
             for checkpointer in self.model_checkpointers:
-                assert isinstance(checkpointer, OpacusCheckpointer), (
-                    "Provided checkpointers must have base class OpacusCheckpointer"
-                )
+                assert isinstance(
+                    checkpointer, OpacusCheckpointer
+                ), "Provided checkpointers must have base class OpacusCheckpointer"
 
 
 class NnUnetServerCheckpointAndStateModule(BaseServerCheckpointAndStateModule):
@@ -571,6 +571,6 @@ class DpScaffoldServerCheckpointAndStateModule(ScaffoldServerCheckpointAndStateM
         """
         if self.model_checkpointers is not None:
             for checkpointer in self.model_checkpointers:
-                assert isinstance(checkpointer, OpacusCheckpointer), (
-                    "Provided checkpointers must have base class OpacusCheckpointer"
-                )
+                assert isinstance(
+                    checkpointer, OpacusCheckpointer
+                ), "Provided checkpointers must have base class OpacusCheckpointer"

--- a/fl4health/clients/nnunet_client.py
+++ b/fl4health/clients/nnunet_client.py
@@ -52,12 +52,12 @@ with warnings.catch_warnings():
     from nnunetv2.experiment_planning.experiment_planners.default_experiment_planner import ExperimentPlanner
     from nnunetv2.experiment_planning.plan_and_preprocess_api import extract_fingerprints, preprocess_dataset
     from nnunetv2.paths import nnUNet_preprocessed, nnUNet_raw
+    from nnunetv2.preprocessing.resampling.default_resampling import compute_new_shape
     from nnunetv2.training.dataloading.utils import unpack_dataset
     from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper
     from nnunetv2.training.lr_scheduler.polylr import PolyLRScheduler
     from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
     from nnunetv2.utilities.dataset_name_id_conversion import convert_id_to_dataset_name
-    from nnunetv2.preprocessing.resampling.default_resampling import compute_new_shape
 
 # grpcio currently has a log spamming bug that seems to be triggered by multithreading/multiprocessing
 # Issue: https://github.com/grpc/grpc/issues/37642
@@ -658,9 +658,9 @@ class NnunetClient(BasicClient):
         loss_targets = prepare_loss_arg(target)
 
         # Ensure we have the same number of predictions and targets
-        assert isinstance(loss_preds, type(loss_targets)), (
-            f"Got unexpected types for preds and targets: {type(loss_preds)} and {type(loss_targets)}"
-        )
+        assert isinstance(
+            loss_preds, type(loss_targets)
+        ), f"Got unexpected types for preds and targets: {type(loss_preds)} and {type(loss_targets)}"
 
         if isinstance(loss_preds, list):
             assert len(loss_preds) == len(loss_targets), (

--- a/fl4health/servers/nnunet_server.py
+++ b/fl4health/servers/nnunet_server.py
@@ -22,6 +22,7 @@ from fl4health.utils.nnunet_utils import NnunetConfig
 from fl4health.utils.parameter_extraction import get_all_model_parameters
 
 with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
     from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
 


### PR DESCRIPTION
# Fix

Clickup Ticket(s):
- [Fix nnunet warnings and log spam](https://app.clickup.com/t/868c8gne1)
- [Replace channel properties in local nnunet plans with local fingerprint](https://app.clickup.com/t/868bugrfy)

The nnunet client must modify the global plans and create a local copy. Previously the only fields being updated or checked for edge case errors were the dataset_name, plans_name, data_identifiers and batch_size. This PR improves the local plans file and tailors it more appropriately to the client's local dataset. Changes include

- Updating additional fields containing information about the datasets median image size both before and after resampling
- Updating the foreground_intensity_properties_per_channel. Before we were using stats from the source dataset for normalization and now we will use local stats
- Updating the batch size check. Previously we were using a batch size limit that was based on an estimate of the source dataset's size, now we are accurately setting the 5% upper bound for batch size

Additionally this PR also fixes a bunch of log errors and deprecation warnings that were introduced in previous PR's. Most annoyingly an error where all logs were printed to the console twice. This was present for all clients, not just the nnunet client.

