### PR TITLE
[CI/CD] Swap out our gha for Github releases for a better one

### DIFF
--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.15.0
         with:
           artifacts: "dist/*"
           generateReleaseNotes: true

--- a/.github/workflows/publish_and_release.yml
+++ b/.github/workflows/publish_and_release.yml
@@ -32,11 +32,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
+          artifacts: "dist/*"
+          generateReleaseNotes: true


### PR DESCRIPTION
# PR Type
Other

# Short Description

The action we're currently using in our CI/CD to make Github Releases is no longer maintained and also doesn't automatically generate release notes. This PR swaps this action out for another one that is still healthy/maintained and has a feature for generating release notes.

Note and fwiw, this is what we use in `llama-deploy` at LlamaIndex.

# Tests Added

N/A