### PR TITLE
[CI/CD] Add `codecov.yml` to add coverage (passing/failing) check

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -71,7 +71,7 @@ If you're using VS Code for development, pre-commit should setup git hooks that 
 
 For code documentation, we try to adhere to the Google docstring style (See [here](https://google.github.io/styleguide/pyguide.html), Section: Comments and Doc-strings). The implementation of an extensive set of comments for the code in this repository is a work-in-progress. However, we are continuing to work towards a better commented state for the code. For development, as stated in the style guide, __any non-trivial or non-obvious methods added to the library should have a doc string__. For our library this applies only to code added to the main library in `fl4health`. Examples, research code, and tests need not incorporate the strict rules of documentation, though clarifying and helpful comments in that code is also __strongly encouraged__.
 
-__NOTE__: As a matter of convention choice, classes are documented through their `__init__` functions rather than at the "class" level.
+> [!NOTE] As a matter of convention choice, classes are documented through their `__init__` functions rather than at the "class" level.
 
 If you are using VS Code a very helpful integration is available to facilitate the creation of properly formatted doc-strings called autoDocstring [VS Code Page](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) and [Documentation](https://github.com/NilsJPWerner/autoDocstring). This tool will automatically generate a docstring template when starting a docstring with triple quotation marks (`"""`). To get the correct format, the following settings should be prescribed in your VS Code settings JSON:
 
@@ -123,4 +123,8 @@ If you use VS Code for development, you can setup the tests with the testing int
 
 In addition to the unit and integration tests through `pytest` a number of **smoke tests** have been implemented and are run remotely on github as well. These tests are housed in `tests/smoke_tests`. All of these smoke tests must also pass for a PR to be eligible for merging to main. These smoke tests ensure that changes to note unintentionally break or alter the current functionality of many of our examples. This helps to ensure that code changes do not have unintended side-effects on already tested and/or working code.
 
-__NOTE__: The contents of the tests folder is not packed with the FL4Health library on release to PyPi
+### Code Coverage
+
+For code coverage, we use [Codecov](https://about.codecov.io/) (by Sentry) and have configured this tool to pass only if a PR's overall code coverage is above 80%.
+
+> [!NOTE] The contents of the tests folder is not packed with the FL4Health library on release to PyPi

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -71,7 +71,8 @@ If you're using VS Code for development, pre-commit should setup git hooks that 
 
 For code documentation, we try to adhere to the Google docstring style (See [here](https://google.github.io/styleguide/pyguide.html), Section: Comments and Doc-strings). The implementation of an extensive set of comments for the code in this repository is a work-in-progress. However, we are continuing to work towards a better commented state for the code. For development, as stated in the style guide, __any non-trivial or non-obvious methods added to the library should have a doc string__. For our library this applies only to code added to the main library in `fl4health`. Examples, research code, and tests need not incorporate the strict rules of documentation, though clarifying and helpful comments in that code is also __strongly encouraged__.
 
-> [!NOTE] As a matter of convention choice, classes are documented through their `__init__` functions rather than at the "class" level.
+> [!NOTE]
+> As a matter of convention choice, classes are documented through their `__init__` functions rather than at the "class" level.
 
 If you are using VS Code a very helpful integration is available to facilitate the creation of properly formatted doc-strings called autoDocstring [VS Code Page](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) and [Documentation](https://github.com/NilsJPWerner/autoDocstring). This tool will automatically generate a docstring template when starting a docstring with triple quotation marks (`"""`). To get the correct format, the following settings should be prescribed in your VS Code settings JSON:
 
@@ -127,4 +128,5 @@ In addition to the unit and integration tests through `pytest` a number of **smo
 
 For code coverage, we use [Codecov](https://about.codecov.io/) (by Sentry) and have configured this tool to pass only if a PR's overall code coverage is above 80%.
 
-> [!NOTE] The contents of the tests folder is not packed with the FL4Health library on release to PyPi
+> [!NOTE]
+> The contents of the tests folder is not packed with the FL4Health library on release to PyPi

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ Note that these strategies are also responsible for unpacking and repacking info
 
 The examples folder contains an extensive set of ways to use the various components of the library, setup the different strategies implemented in the library, and how to run federated learning in general. These examples are an accessible way to learn what is required to experiment with different FL capabilities. Each example has some documentation describing what is being implemented and how to run the code to see it in action. The examples span basic FedAvg implementations to differentially private SCAFFOLD and beyond.
 
-> [!NOTE] The contents of the examples folder is not packed with the FL4Health library on release to PyPi
+> [!NOTE]
+> The contents of the examples folder is not packed with the FL4Health library on release to PyPi
 
 ## Research Code
 
@@ -278,7 +279,8 @@ The research folder houses code associated with various research being conducted
 
 - [FENDA-FL](https://arxiv.org/pdf/2309.16825.pdf) FLamby and GEMINI Experiments (training scripts and model code only). There is a README in these folders that provide details on how to run the hyper-parameter sweeps, evaluations, and other experiments. The GEMINI experiments are not runnable in a general environment, as they require access to GEMINI data, which is securely held, due to patient privacy.
 
-> [!NOTE] The contents of the research folder is not packed with the FL4Health library on release to PyPi
+> [!NOTE]
+> The contents of the research folder is not packed with the FL4Health library on release to PyPi
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Note that these strategies are also responsible for unpacking and repacking info
 
 The examples folder contains an extensive set of ways to use the various components of the library, setup the different strategies implemented in the library, and how to run federated learning in general. These examples are an accessible way to learn what is required to experiment with different FL capabilities. Each example has some documentation describing what is being implemented and how to run the code to see it in action. The examples span basic FedAvg implementations to differentially private SCAFFOLD and beyond.
 
-__NOTE__: The contents of the examples folder is not packed with the FL4Health library on release to PyPi
+> [!NOTE] The contents of the examples folder is not packed with the FL4Health library on release to PyPi
 
 ## Research Code
 
@@ -278,7 +278,7 @@ The research folder houses code associated with various research being conducted
 
 - [FENDA-FL](https://arxiv.org/pdf/2309.16825.pdf) FLamby and GEMINI Experiments (training scripts and model code only). There is a README in these folders that provide details on how to run the hyper-parameter sweeps, evaluations, and other experiments. The GEMINI experiments are not runnable in a general environment, as they require access to GEMINI data, which is securely held, due to patient privacy.
 
-__NOTE__: The contents of the research folder is not packed with the FL4Health library on release to PyPi
+> [!NOTE] The contents of the research folder is not packed with the FL4Health library on release to PyPi
 
 ## Contributing
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: # https://docs.codecov.com/docs/commit-status
+      default:
+        target: 80%
+        threshold: 5%


### PR DESCRIPTION
# PR Type
Other

# Short Description

Our codecov currently only produces a report, which is useful but probably better to have automatic pass/fail depending on coverage scores (as often the case when using coverage tools). With Codecov, we simply need to include the configuration of such setting within a `codecov.yml` file in our project's root dir.

Other:
- I also updated the "NOTE" [admonitions](https://github.com/orgs/community/discussions/16925) in README.md and CONTRIBUTING.md to look nicer.

Specifically:
![image](https://github.com/user-attachments/assets/277a4ab1-6037-4b31-b49b-e4237ed0acd5)



# Tests Added

N/A
