### PR TITLE
[CI/CD] Docs build trigger on all prs to `main`

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -4,18 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .pre-commit-config.yaml
-      - .github/workflows/docs_build.yml
-      - '**.py'
-      - '**.ipynb'
-      - '**.js'
-      - '**.html'
-      - poetry.lock
-      - pyproject.toml
-      - '**.rst'
-      - '**.md'
-  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
# PR Type
Other

# Short Description

Prior to this PR, docs workflow would trigger on pushes to main if certain files (i.e paths) were modified. However, since we have docs now we should just check if all PRs still are able to build docs successfully.

# Tests Added
