### PR TITLE
Fixing an issue with the test_client_level_dp_breast_cancer smoke

### DIFF
--- a/fl4health/strategies/client_dp_fedavgm.py
+++ b/fl4health/strategies/client_dp_fedavgm.py
@@ -308,8 +308,9 @@ class ClientLevelDPFedAvgM(BasicFedAvg):
         if not self.accept_failures and failures:
             return None, {}
 
-        # If first round compute total expected client weight
-        if self.weighted_aggregation and server_round == 1:
+        # If we're doing weighted aggregation, we need to compute a per_client_example_cap. If it has been provided
+        # manually, we skip this step. Otherwise, we perform the necessary calculations.
+        if self.weighted_aggregation and self.per_client_example_cap is None:
             assert self.sample_counts is not None
 
             total_samples = sum(self.sample_counts)

--- a/tests/smoke_tests/run_smoke_test.py
+++ b/tests/smoke_tests/run_smoke_test.py
@@ -634,7 +634,7 @@ async def _wait_for_process_to_finish_and_retrieve_logs(
             raise SmokeTestExecutionError("Process stdout is None")
         full_output, return_code = await asyncio.wait_for(get_output_from_stdout(process.stdout), timeout=timeout)
     except asyncio.exceptions.TimeoutError as e:
-        raise SmokeTestTimeoutError("Timeout for reading logs reached.") from e
+        raise SmokeTestTimeoutError(f"Timeout for reading logs of {process_name} reached.") from e
     except Exception as ex:
         logger.exception(f"Error collecting {process_name} log messages:")
         raise ex

--- a/tests/smoke_tests/test_smoke_tests.py
+++ b/tests/smoke_tests/test_smoke_tests.py
@@ -10,10 +10,10 @@ from .run_smoke_test import (
     run_smoke_test,
 )
 
-# skip some tests that currently fail if running locallly
+# skip some tests that currently fail if running locally
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
-# Marks all test coroutineutines in this module
+# Marks all test coroutines in this module
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
 


### PR DESCRIPTION
# PR Type
Fix

# Short Description

The `test_client_level_dp_breast_cancer` smoke test has been flaky for a long time. I was finally able to carve out some time to investigate. It turns out that the flakiness was, indeed, a subtle bug associated with the way we implemented the strategy when we get unlucky with Poisson sampling.

The gist is as follows:
1. The DP mechanism relies on Poisson sampling clients to participate in each round of FL. For the smoke test, we had a Poisson probability of 2/3 with two clients participating. 
2. If, on the **first round**, we got unlucky and sampled no clients for the `fit()` call, we have an optimization in our base server that will skip doing anything, including aggregate fit.
3. However, if we were doing `weighted_aggregation` and `per_client_example_cap` had not been provided, we're supposed to compute that value (along with `total_client_weight`). If we get unlucky (as in (2)) then we never do this and it was never computed thereafter (due to the `server_round == 1` condition). When we go to `aggregate_fit` in a second round, `self.per_client_example_cap` is still None and we trip the assert on Line 337 of `client_dp_fedavgm.py`. This takes down the server, orphans the clients, and triggers the timeout that we were seeing. 🤦 

The fix is simple, if we're doing `weighted_aggregation` then we just compute `per_client_example_cap` if it is None (regardless of what round) and then don't do it again thereafter.

# Tests Added

None. The smokes will (hopefully) no longer fail on this test intermittently. I tested this fix in two ways

1. I forced the conditions above to happen and verified that it doesn't happen with the fix below and that everything functions as expected.
2. I range the smoke test in a loop 100 times and it didn't fail at any point.
