### PR TITLE
Decoupling some unit tests from examples folder

### DIFF
--- a/tests/clients/test_instance_level.py
+++ b/tests/clients/test_instance_level.py
@@ -10,12 +10,12 @@ from opacus.optimizers.optimizer import DPOptimizer
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
-from examples.models.cnn_model import MnistNetWithBnAndFrozen, Net
 from fl4health.clients.scaffold_client import InstanceLevelDpClient
 from fl4health.utils.dataset import BaseDataset
 from fl4health.utils.metrics import Accuracy
 from fl4health.utils.privacy_utilities import privacy_validate_and_fix_modules
 from tests.clients.fixtures import get_client  # noqa
+from tests.test_utils.models_for_test import MnistNetWithBnAndFrozen, Net
 
 
 class DummyDataset(BaseDataset):

--- a/tests/clients/test_scaffold_client.py
+++ b/tests/clients/test_scaffold_client.py
@@ -5,9 +5,9 @@ from opacus.grad_sample.grad_sample_module import GradSampleModule
 from opacus.optimizers.optimizer import DPOptimizer
 from torch.utils.data import DataLoader
 
-from examples.models.cnn_model import Net
 from fl4health.clients.scaffold_client import DPScaffoldClient, ScaffoldClient
 from tests.clients.fixtures import get_client  # noqa
+from tests.test_utils.models_for_test import Net
 
 
 @pytest.mark.parametrize("type,model", [(ScaffoldClient, Net())])

--- a/tests/test_utils/models_for_test.py
+++ b/tests/test_utils/models_for_test.py
@@ -5,6 +5,26 @@ import torch.nn.functional as F
 from fl4health.model_bases.parallel_split_models import ParallelFeatureJoinMode, ParallelSplitHeadModule
 
 
+class Net(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
 class LinearModel(nn.Module):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Decoupling some unit tests from examples folder. There shouldn't rely on anything in those folder.

# Tests Added

None added. Just migrated to not rely on the examples folder.
