### PR TITLE
[chore] Fix `docs_publish.yml` permmissions

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pages: write  # Work with github pages
     steps:
       - uses: actions/checkout@v4.2.0


### PR DESCRIPTION
# PR Type
Other

# Short Description

Looks like our permissions were a bit too restrictive for our github pages publish action. The reason why we probably weren't seeing this fail in the last couple of weeks since making the change to permissions is that our docs didn't have anything new to upload. Our action only publishes to the `github_pages` branch if there is something new/different in the docs.

# Tests Added

I manually triggered the workflow using cli, and can confirm the workflow now works.

![image](https://github.com/user-attachments/assets/d12a467e-996d-447e-903b-bad75e0ab52e)
