### PR TITLE
Add dynamically created version of clients to `examples/ditto_example`

### DIFF
--- a/examples/ditto_example/README.md
+++ b/examples/ditto_example/README.md
@@ -36,6 +36,7 @@ clients. This is done by simply running (remembering to activate your environmen
 python -m examples.ditto_example.client --dataset_path /path/to/data
 
 # Or, run a ditto client that's built via an application of `make_it_personal` on a `BasicClient`.
+python -m examples.ditto_example.client_dynamic --dataset_path /path/to/data
 ```
 **NOTE**: The argument `dataset_path` has two functions, depending on whether the dataset exists locally or not. If
 the dataset already exists at the path specified, it will be loaded from there. Otherwise, the dataset will be

--- a/examples/ditto_example/README.md
+++ b/examples/ditto_example/README.md
@@ -32,7 +32,10 @@ from the FL4Health directory. The following arguments must be present in the spe
 Once the server has started and logged "FL starting," the next step, in separate terminals, is to start the three
 clients. This is done by simply running (remembering to activate your environment)
 ```bash
+# run a ditto client that's built with `DittoClient`
 python -m examples.ditto_example.client --dataset_path /path/to/data
+
+# Or, run a ditto client that's built via an application of `make_it_personal` on a `BasicClient`.
 ```
 **NOTE**: The argument `dataset_path` has two functions, depending on whether the dataset exists locally or not. If
 the dataset already exists at the path specified, it will be loaded from there. Otherwise, the dataset will be

--- a/examples/ditto_example/client.py
+++ b/examples/ditto_example/client.py
@@ -63,14 +63,14 @@ if __name__ == "__main__":
         "--debug",
         help="[OPTIONAL] Include flag to print DEBUG logs",
         action="store_const",
-        dest="logLevel",
+        dest="log_level",
         const=DEBUG,
         default=INFO,
     )
     args = parser.parse_args()
 
     # Set the log level
-    update_console_handler(level=args.logLevel)
+    update_console_handler(level=args.log_level)
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)

--- a/examples/ditto_example/client_dynamic.py
+++ b/examples/ditto_example/client_dynamic.py
@@ -68,14 +68,14 @@ if __name__ == "__main__":
         "--debug",
         help="[OPTIONAL] Include flag to print DEBUG logs",
         action="store_const",
-        dest="logLevel",
+        dest="log_level",
         const=DEBUG,
         default=INFO,
     )
     args = parser.parse_args()
 
     # Set the log level
-    update_console_handler(level=args.logLevel)
+    update_console_handler(level=args.log_level)
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     data_path = Path(args.dataset_path)

--- a/examples/ditto_example/config.yaml
+++ b/examples/ditto_example/config.yaml
@@ -2,7 +2,7 @@
 n_server_rounds: 5 # The number of rounds to run FL
 
 # Parameters that describe clients
-n_clients: 1 # The number of clients in the FL experiment
+n_clients: 3 # The number of clients in the FL experiment
 local_epochs: 1 # The number of epochs to complete for client
 batch_size: 32 # The batch size for client training
 

--- a/examples/ditto_example/config.yaml
+++ b/examples/ditto_example/config.yaml
@@ -2,7 +2,7 @@
 n_server_rounds: 5 # The number of rounds to run FL
 
 # Parameters that describe clients
-n_clients: 3 # The number of clients in the FL experiment
+n_clients: 1 # The number of clients in the FL experiment
 local_epochs: 1 # The number of epochs to complete for client
 batch_size: 32 # The batch size for client training
 

--- a/examples/ditto_example/server.py
+++ b/examples/ditto_example/server.py
@@ -12,6 +12,7 @@ from fl4health.servers.adaptive_constraint_servers.ditto_server import DittoServ
 from fl4health.strategies.fedavg_with_adaptive_constraint import FedAvgWithAdaptiveConstraint
 from fl4health.utils.config import load_config, make_dict_with_epochs_or_steps
 from fl4health.utils.parameter_extraction import get_all_model_parameters
+from fl4health.utils.random import set_all_random_seeds
 
 
 def fit_config(
@@ -79,8 +80,18 @@ if __name__ == "__main__":
         help="Path to configuration file.",
         default="examples/ditto_example/config.yaml",
     )
+    parser.add_argument(
+        "--seed",
+        action="store",
+        type=int,
+        help="Seed for the random number generators across python, torch, and numpy",
+        required=False,
+    )
     args = parser.parse_args()
 
     config = load_config(args.config_path)
+
+    # Set the random seed for reproducibility
+    set_all_random_seeds(args.seed)
 
     main(config)

--- a/fl4health/mixins/personalized/ditto.py
+++ b/fl4health/mixins/personalized/ditto.py
@@ -1,7 +1,7 @@
 """Ditto Personalized Mixin"""
 
 import warnings
-from logging import INFO, WARN
+from logging import DEBUG, INFO, WARN
 from typing import Any, Protocol, cast, runtime_checkable
 
 import torch
@@ -483,6 +483,9 @@ class DittoPersonalizedMixin(AdaptiveDriftConstrainedMixin):
         global_preds = self._extract_pred(kind="global", preds=preds)
         local_preds = self._extract_pred(kind="local", preds=preds)
 
+        log(DEBUG, f"global_preds has keys {global_preds.keys()}")
+        log(DEBUG, f"local_preds has keys {local_preds.keys()}")
+
         # Compute global model vanilla loss
 
         if hasattr(self, "_special_compute_loss_and_additional_losses"):
@@ -493,10 +496,10 @@ class DittoPersonalizedMixin(AdaptiveDriftConstrainedMixin):
             local_loss, _ = self._special_compute_loss_and_additional_losses(local_preds, features, target)
 
         else:
-            global_loss = self.criterion(global_preds, target)
+            global_loss = self.criterion(global_preds["global"], target)
 
             # Compute local model loss
-            local_loss = self.criterion(local_preds, target)
+            local_loss = self.criterion(local_preds["local"], target)
 
         additional_losses = {"local_loss": local_loss.clone(), "global_loss": global_loss}
 


### PR DESCRIPTION
# PR Type
Documentation

# Short Description

This PR makes use of the recently merged abilities to ditto-ify a `BasicClient` class using our `make_it_personal` class factory function.

# Tests Added

- not any unit tests, but did verify that the example works using both commands to launch a client that are now included in the README
