### PR TITLE
Potential way to simplify a few things in refactor.

### DIFF
--- a/examples/nnunet_example/client.py
+++ b/examples/nnunet_example/client.py
@@ -6,7 +6,7 @@ from os.path import exists, join
 from pathlib import Path
 
 from fl4health.checkpointing.client_module import ClientCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ClientPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ClientStateCheckpointer
 
 with warnings.catch_warnings():
     # Silence deprecation warnings from sentry sdk due to flwr and wandb
@@ -73,7 +73,7 @@ def main(
 
     if intermediate_client_state_dir is not None:
         checkpoint_and_state_module = ClientCheckpointAndStateModule(
-            state_checkpointer=ClientPerRoundStateCheckpointer(Path(intermediate_client_state_dir))
+            state_checkpointer=ClientStateCheckpointer(Path(intermediate_client_state_dir))
         )
     else:
         checkpoint_and_state_module = None

--- a/examples/nnunet_example/server.py
+++ b/examples/nnunet_example/server.py
@@ -13,7 +13,7 @@ from flwr.server.client_manager import SimpleClientManager
 from flwr.server.strategy import FedAvg
 
 from fl4health.checkpointing.server_module import NnUnetServerCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import NnUnetServerPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import NnUnetServerStateCheckpointer
 from fl4health.metrics.metric_aggregation import evaluate_metrics_aggregation_fn, fit_metrics_aggregation_fn
 from fl4health.parameter_exchange.full_exchanger import FullParameterExchanger
 from fl4health.servers.nnunet_server import NnunetServer
@@ -85,7 +85,7 @@ def main(
     )
 
     state_checkpointer = (
-        NnUnetServerPerRoundStateCheckpointer(Path(intermediate_server_state_dir))
+        NnUnetServerStateCheckpointer(Path(intermediate_server_state_dir))
         if intermediate_server_state_dir is not None
         else None
     )

--- a/fl4health/checkpointing/client_module.py
+++ b/fl4health/checkpointing/client_module.py
@@ -132,6 +132,9 @@ class ClientCheckpointAndStateModule:
         function will simply save all the attributes stated in ``ClientStateCheckpointer.snapshot_attrs``.
         This function should only be called if a ``state_checkpointer`` exists in this module.
 
+        Args:
+            client (BasicClient): The client object from which state will be saved.
+
         Raises:
             ValueError: Throws an error if this function is called, but no state checkpointer has been provided
         """
@@ -146,6 +149,9 @@ class ClientCheckpointAndStateModule:
         This function facilitates loading of any pre-existing state (with the name ``checkpoint_name``) in the
         directory of the ``checkpoint_dir``. If the state already exists at the proper path, the state is loaded
         and will be automatically saved into client's attributes. If it doesn't exist, we return False.
+
+        Args:
+            client (BasicClient): client object into which state will be loaded if a checkpoint exists
 
         Raises:
             ValueError: Throws an error if this function is called, but no state checkpointer has been provided

--- a/fl4health/checkpointing/client_module.py
+++ b/fl4health/checkpointing/client_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from enum import Enum
 from logging import INFO

--- a/fl4health/checkpointing/server_module.py
+++ b/fl4health/checkpointing/server_module.py
@@ -157,8 +157,7 @@ class BaseServerCheckpointAndStateModule:
         saving the state of the server's parameters.
 
         Args:
-            state_checkpoint_name (str): Name of the state checkpoint file. The checkpointer itself will have a
-                directory to which state will be saved.
+            server (FlServer): Server object from which state will be extracted and saved.
             server_parameters (Parameters): Like model checkpointers, these are the aggregated Parameters stored by
                 the server representing model state. They are mapped to a torch model architecture via the
                 ``_hydrate_model_for_checkpointing`` function.
@@ -179,6 +178,9 @@ class BaseServerCheckpointAndStateModule:
         If a state_checkpointer is defined and a checkpoint exists at its checkpoint_path, this method hydrates
         the model with the saved state and returns the corresponding server Parameters. If no checkpoint exists,
         it logs this information and returns None.
+
+        Args:
+            server (FlServer): server into which checkpointed state will be loaded if a checkpoint exists
 
         Raises:
             ValueError: Throws an error if this function is called, but no state checkpointer has been provided

--- a/fl4health/checkpointing/server_module.py
+++ b/fl4health/checkpointing/server_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from logging import INFO
 from typing import TYPE_CHECKING

--- a/fl4health/checkpointing/state_checkpointer.py
+++ b/fl4health/checkpointing/state_checkpointer.py
@@ -105,8 +105,8 @@ class StateCheckpointer(ABC):
 
     def load_checkpoint(self) -> dict[str, Any]:
         """
-        Load and return the checkpoint stored in ``checkpoint_dir`` under
-        the  ``checkpoint_name`` if it exists. If it does not exist, an assertion error will be thrown.
+        Load and return the checkpoint stored in ``checkpoint_dir`` under the  ``checkpoint_name`` if it exists. If
+        it does not exist, an assertion error will be thrown.
 
         Returns:
             dict[str, Any]: A dictionary representing the checkpointed state, as loaded by ``torch.load``.
@@ -154,8 +154,8 @@ class StateCheckpointer(ABC):
 
     def save_state(self) -> None:
         """
-        Create a snapshot of the state as defined in ``self.snapshot_attrs``. It is saved in the
-        ``self.checkpoint_dir`` under ``self.checkpoint_name``
+        Create a snapshot of the state as defined in ``self.snapshot_attrs``. It is saved in ``self.checkpoint_dir``
+        under ``self.checkpoint_name``
         """
         for attr_name, (snapshotter, expected_type) in self.snapshot_attrs.items():
             self.snapshot_ckpt.update(self._save_snapshot(snapshotter, attr_name, expected_type))
@@ -334,9 +334,6 @@ class ClientStateCheckpointer(StateCheckpointer):
         Potentially sets a default name for the checkpoint to be saved. If ``checkpoint_dir`` is set but
         ``checkpoint_name`` is None then a default ``checkpoint_name`` based on the underlying name of the client to
         be checkpointed will be set of the form ``f"client_{self.client.client_name}_state.pt"``.
-
-        Args:
-            client (BasicClient): The client to be monitored.
         """
         assert self.client is not None, "Attempting to save client state but client is None"
         # Set the checkpoint name based on client's name if not already provided.
@@ -449,9 +446,6 @@ class ServerStateCheckpointer(StateCheckpointer):
         Potentially sets a default name for the checkpoint to be saved. If ``checkpoint_dir`` is set but
         ``checkpoint_name`` is None then a default ``checkpoint_name`` based on the underlying name of the server to
         be checkpointed will be set of the form ``f"server_{self.server.server_name}_state.pt"``.
-
-        Args:
-            client (BasicClient): The client to be monitored.
         """
         assert self.server is not None, "Attempting to save client state but client is None"
         # Set the checkpoint name based on client's name if not already provided.

--- a/fl4health/clients/basic_client.py
+++ b/fl4health/clients/basic_client.py
@@ -1296,8 +1296,7 @@ class BasicClient(NumPyClient):
         customize which attributes are saved in the checkpoint.
         """
         assert self.checkpoint_and_state_module.state_checkpointer is not None
-        self.checkpoint_and_state_module.state_checkpointer.set_client(self)
-        self.checkpoint_and_state_module.save_state()
+        self.checkpoint_and_state_module.save_state(self)
 
     def _load_client_state(self) -> bool:
         """
@@ -1306,5 +1305,4 @@ class BasicClient(NumPyClient):
         """
         assert self.checkpoint_and_state_module.state_checkpointer is not None
         log(INFO, "Loading client state from checkpoint")
-        self.checkpoint_and_state_module.state_checkpointer.set_client(self)
-        return self.checkpoint_and_state_module.maybe_load_state()
+        return self.checkpoint_and_state_module.maybe_load_state(self)

--- a/fl4health/servers/base_server.py
+++ b/fl4health/servers/base_server.py
@@ -405,8 +405,7 @@ class FlServer(Server):
         ckpt state by the checkpoint module
         """
         assert self.checkpoint_and_state_module.state_checkpointer is not None
-        self.checkpoint_and_state_module.state_checkpointer.set_server(self)
-        self.checkpoint_and_state_module.save_state(self.parameters)
+        self.checkpoint_and_state_module.save_state(self, self.parameters)
 
     def _load_server_state(self) -> bool:
         """
@@ -414,9 +413,8 @@ class FlServer(Server):
         The method can be overridden to add any necessary state when loading the checkpoint.
         """
         assert self.checkpoint_and_state_module.state_checkpointer is not None
-        self.checkpoint_and_state_module.state_checkpointer.set_server(self)
         # Attempt to load the server state if it exists.
-        server_parameters = self.checkpoint_and_state_module.maybe_load_state()
+        server_parameters = self.checkpoint_and_state_module.maybe_load_state(self)
         if server_parameters:
             self.parameters = server_parameters
             log(INFO, "Loaded server state from checkpoint")

--- a/research/picai/fedavg/client.py
+++ b/research/picai/fedavg/client.py
@@ -14,7 +14,7 @@ from torch.optim import Optimizer
 from torchmetrics.classification import MultilabelAveragePrecision
 
 from fl4health.checkpointing.client_module import ClientCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ClientPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ClientStateCheckpointer
 from fl4health.clients.basic_client import BasicClient
 from fl4health.metrics import TorchMetric
 from fl4health.metrics.base_metrics import Metric
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     checkpoint_and_state_module: ClientCheckpointAndStateModule | None
     if args.artifact_dir is not None:
         checkpoint_and_state_module = ClientCheckpointAndStateModule(
-            state_checkpointer=ClientPerRoundStateCheckpointer(Path(args.artifact_dir))
+            state_checkpointer=ClientStateCheckpointer(Path(args.artifact_dir))
         )
     else:
         checkpoint_and_state_module = None

--- a/research/picai/fedavg/server.py
+++ b/research/picai/fedavg/server.py
@@ -11,7 +11,7 @@ from flwr.server.client_manager import SimpleClientManager
 from flwr.server.strategy import FedAvg
 
 from fl4health.checkpointing.server_module import BaseServerCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ServerPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ServerStateCheckpointer
 from fl4health.metrics.metric_aggregation import evaluate_metrics_aggregation_fn, fit_metrics_aggregation_fn
 from fl4health.parameter_exchange.full_exchanger import FullParameterExchanger
 from fl4health.servers.base_server import FlServer
@@ -53,7 +53,7 @@ def main(config: dict[str, Any], server_address: str, n_clients: int, artifact_d
 
     model = get_model()
     parameter_exchanger = FullParameterExchanger()
-    state_checkpointer = ServerPerRoundStateCheckpointer(checkpoint_dir=Path(artifact_dir))
+    state_checkpointer = ServerStateCheckpointer(checkpoint_dir=Path(artifact_dir))
     checkpoint_and_state_module = BaseServerCheckpointAndStateModule(
         model=model,
         parameter_exchanger=parameter_exchanger,

--- a/research/picai/fl_nnunet/start_client.py
+++ b/research/picai/fl_nnunet/start_client.py
@@ -6,7 +6,7 @@ from logging import INFO
 from pathlib import Path
 
 from fl4health.checkpointing.client_module import ClientCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ClientPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ClientStateCheckpointer
 
 with warnings.catch_warnings():
     # Silence deprecation warnings from sentry sdk due to flwr and wandb
@@ -62,7 +62,7 @@ def main(
 
     if intermediate_client_state_dir is not None:
         checkpoint_and_state_module = ClientCheckpointAndStateModule(
-            state_checkpointer=ClientPerRoundStateCheckpointer(Path(intermediate_client_state_dir))
+            state_checkpointer=ClientStateCheckpointer(Path(intermediate_client_state_dir))
         )
     else:
         checkpoint_and_state_module = None

--- a/research/picai/fl_nnunet/start_server.py
+++ b/research/picai/fl_nnunet/start_server.py
@@ -6,7 +6,7 @@ from functools import partial
 from pathlib import Path
 
 from fl4health.checkpointing.server_module import NnUnetServerCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import NnUnetServerPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import NnUnetServerStateCheckpointer
 
 with warnings.catch_warnings():
     # Silence deprecation warnings from sentry sdk due to flwr and wandb
@@ -101,7 +101,7 @@ def main(
         checkpoint_and_state_model = NnUnetServerCheckpointAndStateModule(
             model=None,
             parameter_exchanger=FullParameterExchanger(),
-            state_checkpointer=NnUnetServerPerRoundStateCheckpointer(Path(intermediate_server_state_dir)),
+            state_checkpointer=NnUnetServerStateCheckpointer(Path(intermediate_server_state_dir)),
         )
 
     server = NnunetServer(

--- a/research/picai/single_node_trainer.py
+++ b/research/picai/single_node_trainer.py
@@ -12,7 +12,7 @@ from torch.optim import Optimizer
 
 from fl4health.checkpointing.checkpointer import BestLossTorchModuleCheckpointer
 from fl4health.metrics.metric_managers import MetricManager
-from research.picai.utils import SimpleDictionartCheckpointer
+from research.picai.utils import SimpleDictionaryCheckpointer
 
 
 class SingleNodeTrainer:
@@ -34,7 +34,7 @@ class SingleNodeTrainer:
             os.mkdir(checkpoint_dir)
 
         self.state_checkpoint_name = "ckpt.pkl"
-        self.per_epoch_checkpointer = SimpleDictionartCheckpointer(Path(checkpoint_dir), self.state_checkpoint_name)
+        self.per_epoch_checkpointer = SimpleDictionaryCheckpointer(Path(checkpoint_dir), self.state_checkpoint_name)
         best_metric_checkpoint_name = "best_ckpt.pkl"
         self.checkpointer = BestLossTorchModuleCheckpointer(checkpoint_dir, best_metric_checkpoint_name)
 

--- a/research/picai/single_node_trainer.py
+++ b/research/picai/single_node_trainer.py
@@ -11,8 +11,8 @@ from torch.nn.modules.loss import _Loss
 from torch.optim import Optimizer
 
 from fl4health.checkpointing.checkpointer import BestLossTorchModuleCheckpointer
-from fl4health.checkpointing.state_checkpointer import SimpleDictCheckpointer
 from fl4health.metrics.metric_managers import MetricManager
+from research.picai.utils import SimpleDictionartCheckpointer
 
 
 class SingleNodeTrainer:
@@ -34,7 +34,7 @@ class SingleNodeTrainer:
             os.mkdir(checkpoint_dir)
 
         self.state_checkpoint_name = "ckpt.pkl"
-        self.per_epoch_checkpointer = SimpleDictCheckpointer(Path(checkpoint_dir), self.state_checkpoint_name)
+        self.per_epoch_checkpointer = SimpleDictionartCheckpointer(Path(checkpoint_dir), self.state_checkpoint_name)
         best_metric_checkpoint_name = "best_ckpt.pkl"
         self.checkpointer = BestLossTorchModuleCheckpointer(checkpoint_dir, best_metric_checkpoint_name)
 

--- a/research/picai/utils.py
+++ b/research/picai/utils.py
@@ -1,5 +1,73 @@
+import os
 from enum import Enum
+from logging import ERROR, INFO
+from pathlib import Path
 from typing import Any
+
+import torch
+from flwr.common.logger import log
+
+
+class SimpleDictionartCheckpointer:
+    def __init__(
+        self,
+        checkpoint_dir: Path,
+        checkpoint_name: str,
+    ) -> None:
+        """
+        Simple state checkpointer for saving and loading the state of an object's attributes saved in a dictionary.
+        This class is used to save and load the state of an object to a file. It is not meant to be used for
+        saving in memory.
+
+        Args:
+            checkpoint_dir (Path): Directory to which checkpoints are saved
+            checkpoint_name (str): Name of the checkpoint to be saved
+        """
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_name = checkpoint_name
+        self.checkpoint_path = os.path.join(self.checkpoint_dir, self.checkpoint_name)
+
+    def save_checkpoint(self, checkpoint_dict: dict[str, Any]) -> None:
+        """
+        Save ``checkpoint_dict`` to checkpoint path defined based on checkpointer dir and checkpoint name.
+
+        Args:
+            checkpoint_dict (dict[str, Any]): A dictionary with string keys and values of type Any representing the
+                state to be saved.
+
+        Raises:
+            e: Will throw an error if there is an issue saving the model. ``Torch.save`` seems to swallow errors in
+                this context, so we explicitly surface the error with a try/except.
+        """
+        try:
+            log(INFO, f"Saving the state as {self.checkpoint_path}")
+            torch.save(checkpoint_dict, self.checkpoint_path)
+        except Exception as e:
+            log(ERROR, f"Encountered the following error while saving the checkpoint: {e}")
+            raise e
+
+    def load_checkpoint(self) -> dict[str, Any]:
+        """
+        Load and return the checkpoint stored in ``checkpoint_dir`` under the  ``checkpoint_name`` if it exists. If
+        it does not exist, an assertion error will be thrown.
+
+        Returns:
+            dict[str, Any]: A dictionary representing the checkpointed state, as loaded by ``torch.load``.
+        """
+        assert self.checkpoint_exists()
+        log(INFO, f"Loading state from checkpoint at {self.checkpoint_path}")
+
+        return torch.load(self.checkpoint_path)
+
+    def checkpoint_exists(self) -> bool:
+        """
+        Check if a checkpoint exists at the checkpoint_path constructed as
+        ``checkpoint_dir`` + ``checkpoint_name`` during initialization.
+
+        Returns:
+            bool: True if checkpoint exists, otherwise false.
+        """
+        return os.path.exists(self.checkpoint_path)
 
 
 class MultiAttributeEnum(Enum):

--- a/research/picai/utils.py
+++ b/research/picai/utils.py
@@ -8,16 +8,15 @@ import torch
 from flwr.common.logger import log
 
 
-class SimpleDictionartCheckpointer:
+class SimpleDictionaryCheckpointer:
     def __init__(
         self,
         checkpoint_dir: Path,
         checkpoint_name: str,
     ) -> None:
         """
-        Simple state checkpointer for saving and loading the state of an object's attributes saved in a dictionary.
-        This class is used to save and load the state of an object to a file. It is not meant to be used for
-        saving in memory.
+        A simple state checkpointer that saves and loads an object's attribute state (stored in a dictionary) to and
+        from a file.
 
         Args:
             checkpoint_dir (Path): Directory to which checkpoints are saved

--- a/tests/checkpointing/test_state_checkpointer.py
+++ b/tests/checkpointing/test_state_checkpointer.py
@@ -206,8 +206,7 @@ def test_client_state_checkpointing_with_custom_attrs(tmp_path: Path) -> None:
     fl_client.client_name = "updated_client"
 
     checkpointer.save_client_state(fl_client)
-
-    assert not checkpointer.checkpoint_exists()
+    assert checkpointer.checkpoint_exists()
 
     # Use the copy_client to load the state.
     checkpointer.load_client_state(copy_client)

--- a/tests/checkpointing/test_state_checkpointer.py
+++ b/tests/checkpointing/test_state_checkpointer.py
@@ -230,7 +230,7 @@ def test_client_state_checkpointing_with_custom_attrs(tmp_path: Path) -> None:
 
 def test_server_state_checkpointer(tmp_path: Path) -> None:
     """
-    Test the server per round state checkpointer.
+    Test the server state checkpointer.
     """
     fl_server = FlServer(
         client_manager=SimpleClientManager(),

--- a/tests/servers/test_base_server.py
+++ b/tests/servers/test_base_server.py
@@ -14,7 +14,7 @@ from peft import LoraConfig, get_peft_model
 
 from fl4health.checkpointing.checkpointer import BestLossTorchModuleCheckpointer
 from fl4health.checkpointing.server_module import BaseServerCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ServerPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ServerStateCheckpointer
 from fl4health.client_managers.base_sampling_manager import SimpleClientManager
 from fl4health.client_managers.poisson_sampling_manager import PoissonSamplingClientManager
 from fl4health.metrics.base_metrics import TEST_LOSS_KEY, TEST_NUM_EXAMPLES_KEY, MetricPrefix
@@ -37,7 +37,7 @@ def test_hydration_no_model_with_checkpointer(tmp_path: Path) -> None:
     checkpoint_dir = tmp_path.joinpath("resources")
     checkpoint_dir.mkdir()
     checkpointer = BestLossTorchModuleCheckpointer(str(checkpoint_dir), "best_model.pkl")
-    state_checkpointer = ServerPerRoundStateCheckpointer(checkpoint_dir=checkpoint_dir)
+    state_checkpointer = ServerStateCheckpointer(checkpoint_dir=checkpoint_dir)
     # Checkpointer is defined but there is no server-side model defined to produce a model from the server state.
     # An assertion error should be throw stating this
     with pytest.raises(AssertionError) as assertion_error:

--- a/tests/smoke_tests/load_from_checkpoint_example/client.py
+++ b/tests/smoke_tests/load_from_checkpoint_example/client.py
@@ -12,7 +12,7 @@ from torch.utils.data import DataLoader
 
 from examples.models.cnn_model import Net
 from fl4health.checkpointing.client_module import ClientCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ClientPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ClientStateCheckpointer
 from fl4health.clients.basic_client import BasicClient
 from fl4health.metrics import Accuracy
 from fl4health.metrics.base_metrics import Metric
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     checkpoint_and_state_module: ClientCheckpointAndStateModule | None
     if args.intermediate_client_state_dir is not None:
         checkpoint_and_state_module = ClientCheckpointAndStateModule(
-            state_checkpointer=ClientPerRoundStateCheckpointer(Path(args.intermediate_client_state_dir))
+            state_checkpointer=ClientStateCheckpointer(Path(args.intermediate_client_state_dir))
         )
     else:
         checkpoint_and_state_module = None

--- a/tests/smoke_tests/load_from_checkpoint_example/server.py
+++ b/tests/smoke_tests/load_from_checkpoint_example/server.py
@@ -9,12 +9,9 @@ from flwr.server.client_manager import SimpleClientManager
 from flwr.server.strategy import FedAvg
 
 from examples.models.cnn_model import Net
-from fl4health.checkpointing.checkpointer import (
-    BestLossTorchModuleCheckpointer,
-    LatestTorchModuleCheckpointer,
-)
+from fl4health.checkpointing.checkpointer import BestLossTorchModuleCheckpointer, LatestTorchModuleCheckpointer
 from fl4health.checkpointing.server_module import BaseServerCheckpointAndStateModule
-from fl4health.checkpointing.state_checkpointer import ServerPerRoundStateCheckpointer
+from fl4health.checkpointing.state_checkpointer import ServerStateCheckpointer
 from fl4health.metrics.metric_aggregation import evaluate_metrics_aggregation_fn, fit_metrics_aggregation_fn
 from fl4health.parameter_exchange.full_exchanger import FullParameterExchanger
 from fl4health.reporting import JsonReporter
@@ -54,7 +51,7 @@ def main(config: dict[str, Any], intermediate_server_state_dir: str, server_name
         BestLossTorchModuleCheckpointer(config["checkpoint_path"], "best_model.pkl"),
         LatestTorchModuleCheckpointer(config["checkpoint_path"], "latest_model.pkl"),
     ]
-    state_checkpointer = ServerPerRoundStateCheckpointer(Path(intermediate_server_state_dir))
+    state_checkpointer = ServerStateCheckpointer(Path(intermediate_server_state_dir))
     checkpoint_and_state_module = BaseServerCheckpointAndStateModule(
         model=model,
         parameter_exchanger=parameter_exchanger,

--- a/tests/utils/test_early_stopper.py
+++ b/tests/utils/test_early_stopper.py
@@ -35,9 +35,9 @@ def test_early_stopper_patience_3(tmp_path: Path) -> None:
     mock_client = MockBasicClient()
     early_stopper = EarlyStopper(
         client=mock_client,
+        train_loop_checkpoint_dir=tmp_path,
         patience=3,
         interval_steps=1,
-        train_loop_checkpoint_dir=tmp_path,
     )
     # Override the snapshot_attrs of early stopper's state_checkpointer for test simplicity.
     early_stopper.state_checkpointer.snapshot_attrs = {
@@ -63,9 +63,9 @@ def test_early_stopper_patience_4(tmp_path: Path) -> None:
     mock_client = MockBasicClient()
     early_stopper = EarlyStopper(
         client=mock_client,
+        train_loop_checkpoint_dir=tmp_path,
         patience=4,
         interval_steps=1,
-        train_loop_checkpoint_dir=tmp_path,
     )
     # Override the snapshot_attrs of early stopper's state_checkpointer for test simplicity.
     early_stopper.state_checkpointer.snapshot_attrs = {


### PR DESCRIPTION
# PR Type
Other

# Short Description

The goal here was just to simplify a few things about the new state checkpointing structure that @fatemetkl is proposing. This includes: 
1. Collapsing a few of the more specific state checkpointing classes into single implementations with defaults that can be overridden
2. Removing the option for in-memory storage. It felt like we had several edge-case type behaviors because of it and I wasn't really sure when one might absolutely need to do that.
3. I also cleaned up a few of the docstrings to be more in the Google docstring style we've been trying to unify on.

# Tests Added

Just migrated existing tests to use the new structures and make sure they still passed.
