### PR TITLE
[chore-fix] Simplify cache key in testing workflows

### DIFF
--- a/.github/workflows/smoke_tests.yaml
+++ b/.github/workflows/smoke_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         id: cached-poetry-dependencies
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
         id: cached-poetry-dependencies
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --with "dev, test"
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Our cached environments were not being hit, and so new venvs were being created. NOTE: this was happening for both of our unit test and smoke tests workflows.

In the IDE, you can see a clue of the issue: the id `full-python-version` was missing in the steps. To simplify, and since we're only running these jobs with a single python version, I'm removing this id from the cache key.

![image](https://github.com/user-attachments/assets/98a834cc-c598-499a-8ad4-20291badb8f5)

# Tests Added
